### PR TITLE
Fix: add various setup improvements

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2023 Lido
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Diff your Ethereum smart contracts code from GitHub against Etherscan verified s
 
 ## Prerequisites
 This project was developed using these dependencies with their exact versions listed below:
-- Python ^3.10
-- Poetry ^1.4
+- Python 3.10
+- Poetry 1.4
 
 Other versions may work as well but were not tested at all.
 
@@ -30,14 +30,14 @@ alternatively, you could proceed with `pipx`:
 pipx install poetry~=1.4
 ```
 
-2. Install Python dependencies
-```shell
-poetry install
-```
-
-3. Activate poetry virtual environment,
+2. Activate poetry virtual environment,
 ```shell
 poetry shell
+```
+
+3. Install Python dependencies
+```shell
+poetry install
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,12 +1,50 @@
 # Diffyscan
 
-Diff your Github code against Etherscan verified source code.
+![python ^3.10](https://img.shields.io/badge/python-^3.10-blue)
+![poetry ^1.4](https://img.shields.io/badge/poetry-^1.4-blue)
+![license MIT](https://img.shields.io/badge/license-MIT-brightgreen)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
+Diff your Ethereum smart contracts code from GitHub against Etherscan verified source code.
+
+## Prerequisites
+This project was developed using these dependencies with their exact versions listed below:
+- Python ^3.10
+- Poetry ^1.4
+
+Other versions may work as well but were not tested at all.
+
+## Setup
+
+1. Install Poetry
+
+Use the following command to install poetry:
+
+```shell
+pip install --user poetry~=1.4
+```
+
+alternatively, you could proceed with `pipx`:
+
+```shell
+pipx install poetry~=1.4
+```
+
+2. Install Python dependencies
+```shell
+poetry install
+```
+
+3. Activate poetry virtual environment,
+```shell
+poetry shell
+```
 
 ## Usage
 
 Set your Etherscan token to fetch verified source code,
 ```bash
-export ETHERSCAN_API_TOKEN=<your-etherscan-token>
+export ETHERSCAN_TOKEN=<your-etherscan-token>
 ```
 
 Set your Github token to query API without strict rate limiting,

--- a/main.py
+++ b/main.py
@@ -129,7 +129,7 @@ def main():
 
     if contract_address is not None:
         if contract_name is None:
-            logger.error("Contract name isn't set for address", f"{contract_address}")
+            logger.error("Please set the 'CONTRACT_NAME' env var for address", f"{contract_address}")
             sys.exit(1)
 
         logger.info(f"Running diff for a single contract {contract_name} deployed at {contract_address}...")

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def run_diff(config, name, address, etherscan_api_token, github_api_token):
     )
 
     if (contract_name != name):
-        logger.error("Contract name in config does not match with etherscan", f"{address}: {name} != {contract_name}")
+        logger.error("Contract name in config does not match with Etherscan", f"{address}: {name} != {contract_name}")
         sys.exit(1)
 
     files_count = len(source_files)
@@ -59,7 +59,7 @@ def run_diff(config, name, address, etherscan_api_token, github_api_token):
         ):
             repo = config["dependencies"].get(origin)
         else:
-            logger.warn(f"No file in github repo for: {filepath}")
+            logger.warn(f"No file in GitHub repo for: {filepath}")
             logger.divider()
 
         diff_report_filename = None
@@ -114,7 +114,7 @@ def main():
     logger.divider()
 
     logger.info("Loading API tokens...")
-    etherscan_api_token = load_env("ETHERSCAN_API_TOKEN", masked=True)
+    etherscan_api_token = load_env("ETHERSCAN_TOKEN", masked=True)
     github_api_token = load_env("GITHUB_API_TOKEN", masked=True)
     contract_address = load_env("CONTRACT_ADDRESS", required=False)
     contract_name = load_env("CONTRACT_NAME", required=False)
@@ -128,7 +128,11 @@ def main():
     config = load_config()
 
     if contract_address is not None:
-        logger.info(f"Running diff for a single contract {contract_name} ...")
+        if contract_name is None:
+            logger.error("Contract name isn't set for address", f"{contract_address}")
+            sys.exit(1)
+
+        logger.info(f"Running diff for a single contract {contract_name} deployed at {contract_address}...")
         run_diff(config, contract_name, contract_address, etherscan_api_token, github_api_token)
     else:
         contracts = config["contracts"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,13 @@
 [tool.poetry]
 name = "etherscan-github-diff-checker"
 version = "0.1.0"
-description = ""
+description = "Diff your Ethereum smart contracts code from GitHub against Etherscan verified source code."
 authors = ["Azat Serikov <azatsdev@gmail.com>"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/lidofinance/diffyscan"
+
+keywords = ["ethereum", "diff", "sources"]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
- Add MIT license
- Enrich the `pyproject.toml` contents
- Use `ETHERSCAN_TOKEN` instead of `ETHERSCAN_API_TOKEN` for compatibility with web3 frameworks such as brownie
- Provide setup instructions and list dependencies
- Exit early if a single contract requested without its name