### PR TITLE
Replace network parameter with indexer host in config

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -5,7 +5,7 @@
         "0x710B3303fB508a84F10793c1106e32bE873C24cd": "DepositSecurityModule",
         "0x388C818CA8B9251b393131C08a736A67ccB19297": "LidoExecutionLayerRewardsVault"
     },
-    "network": "mainnet",
+    "indexer_host": "api.etherscan.io",
     "github_repo": "https://github.com/lidofinance/lido-dao/tree/master",
     "dependencies": {
         "@aragon/os": "https://github.com/aragon/aragonOS/tree/f3ae59b00f73984e562df00129c925339cd069ff",

--- a/config.sample.json
+++ b/config.sample.json
@@ -5,7 +5,7 @@
         "0x710B3303fB508a84F10793c1106e32bE873C24cd": "DepositSecurityModule",
         "0x388C818CA8B9251b393131C08a736A67ccB19297": "LidoExecutionLayerRewardsVault"
     },
-    "indexer_host": "api.etherscan.io",
+    "etherscan_hostname": "api.etherscan.io",
     "github_repo": "https://github.com/lidofinance/lido-dao/tree/master",
     "dependencies": {
         "@aragon/os": "https://github.com/aragon/aragonOS/tree/f3ae59b00f73984e562df00129c925339cd069ff",

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from utils.logger import logger
 def run_diff(config, name, address, etherscan_api_token, github_api_token):
     logger.divider()
     logger.okay("Contract", address)
-    logger.okay("Indexer Host", config["indexer_host"])
+    logger.okay("Etherscan Hostname", config["etherscan_hostname"])
     logger.okay("Repo", config["github_repo"])
 
     logger.divider()
@@ -21,7 +21,7 @@ def run_diff(config, name, address, etherscan_api_token, github_api_token):
     logger.info("Fetching source code from Etherscan...")
     contract_name, source_files = get_contract_from_etherscan(
         token=etherscan_api_token,
-        indexer_host=config["indexer_host"],
+        etherscan_hostname=config["etherscan_hostname"],
         contract=address,
     )
 

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from utils.logger import logger
 def run_diff(config, name, address, etherscan_api_token, github_api_token):
     logger.divider()
     logger.okay("Contract", address)
-    logger.okay("Network", config["network"])
+    logger.okay("Indexer Host", config["indexer_host"])
     logger.okay("Repo", config["github_repo"])
 
     logger.divider()
@@ -21,7 +21,7 @@ def run_diff(config, name, address, etherscan_api_token, github_api_token):
     logger.info("Fetching source code from Etherscan...")
     contract_name, source_files = get_contract_from_etherscan(
         token=etherscan_api_token,
-        network=config["network"],
+        indexer_host=config["indexer_host"],
         contract=address,
     )
 

--- a/utils/etherscan.py
+++ b/utils/etherscan.py
@@ -5,9 +5,8 @@ from utils.common import fetch
 from utils.logger import logger
 
 
-def get_contract_from_etherscan(token, network, contract):
-    etherscan_api_subdomain = "" if network == "mainnet" else f"-{network}"
-    etherscan_link = f"https://api{etherscan_api_subdomain}.etherscan.io/api?module=contract&action=getsourcecode&address={contract}&apikey={token}"
+def get_contract_from_etherscan(token, indexer_host, contract):
+    etherscan_link = f"https://{indexer_host}/api?module=contract&action=getsourcecode&address={contract}&apikey={token}"
 
     response = fetch(etherscan_link)
 

--- a/utils/etherscan.py
+++ b/utils/etherscan.py
@@ -5,8 +5,8 @@ from utils.common import fetch
 from utils.logger import logger
 
 
-def get_contract_from_etherscan(token, indexer_host, contract):
-    etherscan_link = f"https://{indexer_host}/api?module=contract&action=getsourcecode&address={contract}&apikey={token}"
+def get_contract_from_etherscan(token, etherscan_hostname, contract):
+    etherscan_link = f"https://{etherscan_hostname}/api?module=contract&action=getsourcecode&address={contract}&apikey={token}"
 
     response = fetch(etherscan_link)
 


### PR DESCRIPTION
### WHAT
Setting network name isn't enough for some indexers. For instance base has **.org** name instead of **.io**.
 
#### HOW
Use indexer host as parameter to make **diffyscan** more flexible.