### PR TITLE
Feat/l2 target lidofinance

### DIFF
--- a/config_samples/linea/mainnet/linea_mainnet_config_L1.json
+++ b/config_samples/linea/mainnet/linea_mainnet_config_L1.json
@@ -6,7 +6,7 @@
     "explorer_hostname": "api.etherscan.io",
     "explorer_token_env_var": "ETHERSCAN_EXPLORER_TOKEN",
     "github_repo": {
-        "url": "https://github.com/Consensys/linea-contracts-fix",
+        "url": "https://github.com/lidofinance/linea-contracts-fix",
         "commit": "0949c4096664e613f73ed3ce51c32f97fc56cdef",
         "relative_root": ""
     },

--- a/config_samples/linea/mainnet/linea_mainnet_config_L2.json
+++ b/config_samples/linea/mainnet/linea_mainnet_config_L2.json
@@ -2,13 +2,12 @@
     "contracts": {
         "0xa11ba93afbd6d18e26fefdb2c6311da6c9b370d6": "ProxyAdmin",
         "0x2bfdf4a0d54c93a4baf74f8dcea8a275d8ee97a9": "TokenBridge",
-        "0xc0583e2F5930EDE5Fab9D57bAC4169878730B010": "CustomBridgedToken",
         "0xF951d7592e03eDB0Bab3D533935e678Ce64Eb927": "ProxyAdmin"
     },
     "explorer_hostname": "api.lineascan.build",
     "explorer_token_env_var": "LINEA_EXPLORER_TOKEN",
     "github_repo": {
-        "url": "https://github.com/Consensys/linea-contracts-fix",
+        "url": "https://github.com/lidofinance/linea-contracts-fix",
         "commit": "0949c4096664e613f73ed3ce51c32f97fc56cdef",
         "relative_root": ""
     },

--- a/config_samples/linea/mainnet/linea_mainnet_config_L2_custom_bridged_token.json
+++ b/config_samples/linea/mainnet/linea_mainnet_config_L2_custom_bridged_token.json
@@ -1,12 +1,12 @@
 {
     "contracts": {
-        "0x6ccfd65b0b14f67259c77ca6267104e058ddb292": "TokenBridge"
+        "0xc0583e2F5930EDE5Fab9D57bAC4169878730B010": "CustomBridgedToken"
     },
-    "explorer_hostname": "api.etherscan.io",
-    "explorer_token_env_var": "ETHERSCAN_EXPLORER_TOKEN",
+    "explorer_hostname": "api.lineascan.build",
+    "explorer_token_env_var": "LINEA_EXPLORER_TOKEN",
     "github_repo": {
-        "url": "https://github.com/lidofinance/linea-contracts-fix",
-        "commit": "0949c4096664e613f73ed3ce51c32f97fc56cdef",
+        "url": "https://github.com/lidofinance/linea-contracts",
+        "commit": "3cf85529fd4539eb06ba998030c37e47f98c528a",
         "relative_root": ""
     },
     "dependencies": {

--- a/config_samples/linea/mainnet/linea_mainnet_config_L2_gov.json
+++ b/config_samples/linea/mainnet/linea_mainnet_config_L2_gov.json
@@ -5,8 +5,8 @@
     "explorer_hostname": "api.lineascan.build",
     "explorer_token_env_var": "LINEA_EXPLORER_TOKEN",
     "github_repo": {
-        "url": "https://github.com/Consensys/governance-crosschain-bridges",
-        "commit": "315308a2640c696937185732159b130417f29997",
+        "url": "https://github.com/lidofinance/governance-crosschain-bridges",
+        "commit": "7d4fd35e92688d7aa56ae2f94872f851bacae50c",
         "relative_root": ""
     },
     "dependencies": {}

--- a/config_samples/linea/mainnet/linea_mainnet_config_L2_proxy.json
+++ b/config_samples/linea/mainnet/linea_mainnet_config_L2_proxy.json
@@ -6,7 +6,7 @@
     "explorer_hostname": "api.lineascan.build",
     "explorer_token_env_var": "LINEA_EXPLORER_TOKEN",
     "github_repo": {
-        "url": "https://github.com/Consensys/linea-contracts-fix",
+        "url": "https://github.com/lidofinance/linea-contracts-fix",
         "commit": "0949c4096664e613f73ed3ce51c32f97fc56cdef",
         "relative_root": ""
     },

--- a/config_samples/mantle/mainnet/mantle_mainnet_config_L1.json
+++ b/config_samples/mantle/mainnet/mantle_mainnet_config_L1.json
@@ -4,8 +4,9 @@
         "0x6fBBe1Af52D22557D7F161Dc5952E306F4742e23": "L1ERC20TokenBridge"
     },
     "explorer_hostname": "api.etherscan.io",
+    "explorer_token_env_var": "ETHERSCAN_EXPLORER_TOKEN",
     "github_repo": {
-        "url": "https://github.com/mantlenetworkio/lido-l2",
+        "url": "https://github.com/lidofinance/lido-l2",
         "commit": "cdd513cd3d25699a8757f8e730b443a495d0240e",
         "relative_root": ""
     },

--- a/config_samples/mantle/mainnet/mantle_mainnet_config_L2.json
+++ b/config_samples/mantle/mainnet/mantle_mainnet_config_L2.json
@@ -7,7 +7,7 @@
     },
     "explorer_hostname": "explorer.mantle.xyz",
     "github_repo": {
-        "url": "https://github.com/mantlenetworkio/lido-l2",
+        "url": "https://github.com/lidofinance/lido-l2",
         "commit": "cdd513cd3d25699a8757f8e730b443a495d0240e",
         "relative_root": ""
     },

--- a/config_samples/mantle/mainnet/mantle_mainnet_config_L2_gov.json
+++ b/config_samples/mantle/mainnet/mantle_mainnet_config_L2_gov.json
@@ -4,7 +4,7 @@
     },
     "explorer_hostname": "explorer.mantle.xyz",
     "github_repo": {
-        "url": "hhttps://github.com/lidofinance/governance-crosschain-bridges",
+        "url": "https://github.com/lidofinance/governance-crosschain-bridges",
         "commit": "8fa25b0080dd3dcc2390313631aea6796a12c9d8",
         "relative_root": ""
     },

--- a/config_samples/mantle/testnet/mantle_testnet_config_L1.json
+++ b/config_samples/mantle/testnet/mantle_testnet_config_L1.json
@@ -4,8 +4,9 @@
         "0x8bed2E40522E21119B8A78A4842767c9bCceC47b": "L1ERC20TokenBridge"
     },
     "explorer_hostname": "api-goerli.etherscan.io",
+    "explorer_token_env_var": "ETHERSCAN_EXPLORER_TOKEN",
     "github_repo": {
-        "url": "https://github.com/mantlenetworkio/lido-l2",
+        "url": "https://github.com/lidofinance/lido-l2",
         "commit": "cdd513cd3d25699a8757f8e730b443a495d0240e",
         "relative_root": ""
     },

--- a/config_samples/mantle/testnet/mantle_testnet_config_L2.json
+++ b/config_samples/mantle/testnet/mantle_testnet_config_L2.json
@@ -7,7 +7,7 @@
     },
     "explorer_hostname": "explorer.testnet.mantle.xyz",
     "github_repo": {
-        "url": "https://github.com/mantlenetworkio/lido-l2",
+        "url": "https://github.com/lidofinance/lido-l2",
         "commit": "cdd513cd3d25699a8757f8e730b443a495d0240e",
         "relative_root": ""
     },

--- a/config_samples/zksync/mainnet/zksync_mainnet_config_L1.json
+++ b/config_samples/zksync/mainnet/zksync_mainnet_config_L1.json
@@ -6,8 +6,9 @@
         "0x9a810469F4a451Ebb7ef53672142053b4971587c": "L1ERC20Bridge"
     },
     "explorer_hostname": "api.etherscan.io",
+    "explorer_token_env_var": "ETHERSCAN_EXPLORER_TOKEN",
     "github_repo": {
-        "url": "https://github.com/txfusion/lido-l2",
+        "url": "https://github.com/lidofinance/lido-l2",
         "commit": "fa6a77e694a34dc6f03d57bb8c934941e554ac9d",
         "relative_root": "zksync"
     },

--- a/config_samples/zksync/mainnet/zksync_mainnet_config_L2.json
+++ b/config_samples/zksync/mainnet/zksync_mainnet_config_L2.json
@@ -10,7 +10,7 @@
     },
     "explorer_hostname": "zksync2-mainnet-explorer.zksync.io",
     "github_repo": {
-        "url": "https://github.com/txfusion/lido-l2",
+        "url": "https://github.com/lidofinance/lido-l2",
         "commit": "fa6a77e694a34dc6f03d57bb8c934941e554ac9d",
         "relative_root": "zksync"
     },

--- a/config_samples/zksync/testnet/zksync_testnet_config_L1.json
+++ b/config_samples/zksync/testnet/zksync_testnet_config_L1.json
@@ -6,9 +6,10 @@
         "0xc3f1A4C13532cc9DDeA36B54d83A427B8D4AaeEe": "L1ERC20Bridge"
     },
     "explorer_hostname": "api-goerli.etherscan.io",
+    "explorer_token_env_var": "ETHERSCAN_EXPLORER_TOKEN",
     "github_repo": {
-        "url": "https://github.com/txfusion/lido-l2",
-        "commit": "28d8f7539a57972a83f41a8809fee4c4766009a0",
+        "url": "https://github.com/lidofinance/lido-l2",
+        "commit": "fa6a77e694a34dc6f03d57bb8c934941e554ac9d",
         "relative_root": "zksync"
     },
     "dependencies": {

--- a/config_samples/zksync/testnet/zksync_testnet_config_L2.json
+++ b/config_samples/zksync/testnet/zksync_testnet_config_L2.json
@@ -10,8 +10,8 @@
     },
     "explorer_hostname": "zksync2-testnet-explorer.zksync.dev",
     "github_repo": {
-        "url": "https://github.com/txfusion/lido-l2",
-        "commit": "28d8f7539a57972a83f41a8809fee4c4766009a0",
+        "url": "https://github.com/lidofinance/lido-l2",
+        "commit": "fa6a77e694a34dc6f03d57bb8c934941e554ac9d",
         "relative_root": "zksync"
     },
     "dependencies": {

--- a/utils/explorer.py
+++ b/utils/explorer.py
@@ -52,7 +52,7 @@ def _get_contract_from_zksync(zksync_explorer_hostname, contract):
         sys.exit(1)
 
     data = response["request"]
-    if "ContractName" not in data:
+    if "contractName" not in data:
         _errorNoSourceCodeAndExit(contract)
 
     contract_name = data["contractName"].split(":")[-1]


### PR DESCRIPTION
Update linea, mantle, zksync sample configs: make l2 repo references target repos in lidofinance

Also got sure the commits in configs correspond to the commits in the audits.

NB linea testnet not updated because it is cumbersome on Goerli is going to die

Plus two small fixes