### PR TITLE
Cfg: add wstETH on Metis Sepolia

### DIFF
--- a/config_samples/metis/testnet/metis_testnet_config_L1.json
+++ b/config_samples/metis/testnet/metis_testnet_config_L1.json
@@ -1,0 +1,27 @@
+{
+    "contracts": {
+        "0xAA4aCF50199096EefC7e211021600C57C6CDb472": "OssifiableProxy",
+        "0x461cfAecD0360bAFfC9c690599305f05a1731326": "L1ERC20TokenBridgeMetis"
+    },
+    "explorer_hostname": "api-sepolia.etherscan.io",
+    "explorer_token_env_var": "ETHERSCAN_TOKEN",
+    "github_repo": {
+        "url": "https://github.com/MohammadShahin/lido-l2-metis",
+        "commit": "ba10d253721cb60efceab0cb55033fcf14f6262b",
+        "relative_root": ""
+    },
+    "dependencies": {
+        "@openzeppelin/contracts": {
+            "url": "https://github.com/OpenZeppelin/openzeppelin-contracts",
+            "commit": "dc44c9f1a4c3b10af99492eed84f83ed244203f6",
+            "relative_root": "contracts",
+            "//": "version 4.9.6"
+        },
+        "@openzeppelin/contracts-upgradeable": {
+            "url": "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable",
+            "commit": "2d081f24cac1a867f6f73d512f2022e1fa987854",
+            "relative_root": "contracts",
+            "//": "version 4.9.6"
+        }
+    }
+}

--- a/config_samples/metis/testnet/metis_testnet_config_L2.json
+++ b/config_samples/metis/testnet/metis_testnet_config_L2.json
@@ -1,0 +1,28 @@
+{
+    "contracts": {
+        "0xf55E51a283f36C04009Bd7b6C49f26CD46Ecf090": "OssifiableProxy",
+        "0x79695a6ccf98355028ee7f4fdb42f7dac31c4b63": "L2ERC20TokenBridgeMetis",
+        "0x740C6Bf96A74bc555286Aa55D8B907d1bb5b59Ce": "OssifiableProxy",
+        "0xfdc26997c288435bE1c369676d8481f853A7ebd4": "ERC20BridgedPermit"
+    },
+    "explorer_hostname": "sepolia-explorer-api.metisdevops.link",
+    "github_repo": {
+        "url": "https://github.com/MohammadShahin/lido-l2-metis",
+        "commit": "ba10d253721cb60efceab0cb55033fcf14f6262b",
+        "relative_root": ""
+    },
+    "dependencies": {
+        "@openzeppelin/contracts": {
+            "url": "https://github.com/OpenZeppelin/openzeppelin-contracts",
+            "commit": "dc44c9f1a4c3b10af99492eed84f83ed244203f6",
+            "relative_root": "contracts",
+            "//": "version 4.9.6"
+        },
+        "@openzeppelin/contracts-upgradeable": {
+            "url": "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable",
+            "commit": "2d081f24cac1a867f6f73d512f2022e1fa987854",
+            "relative_root": "contracts",
+            "//": "version 4.9.6"
+        }
+    }
+}

--- a/config_samples/metis/testnet/metis_testnet_config_L2_gov.json
+++ b/config_samples/metis/testnet/metis_testnet_config_L2_gov.json
@@ -1,0 +1,12 @@
+{
+    "contracts": {
+        "0x38c82a94DEF88E14dd1d6fB8220CFE6C660C4375": "OptimismBridgeExecutor"
+    },
+    "explorer_hostname": "sepolia-explorer-api.metisdevops.link",
+    "github_repo": {
+        "url": "https://github.com/lidofinance/governance-crosschain-bridges",
+        "commit": "8fa25b0080dd3dcc2390313631aea6796a12c9d8",
+        "relative_root": ""
+    },
+    "dependencies": {  }
+}

--- a/utils/explorer.py
+++ b/utils/explorer.py
@@ -77,6 +77,22 @@ def _get_contract_from_mantle(mantle_explorer_hostname, contract):
     return (data["ContractName"], source_files)
 
 
+def _get_contract_from_metis(metis_explorer_hostname, contract):
+    metis_explorer_link = (
+        f"https://{metis_explorer_hostname}/api/v2/smart-contracts/{contract}"
+    )
+    response = fetch(metis_explorer_link)
+
+    if "name" not in response:
+        _errorNoSourceCodeAndExit(contract)
+
+    source_files = [(response["file_path"], {"content": response["source_code"]})]
+    for entry in response.get("additional_sources", []):
+        source_files.append((entry["file_path"], {"content": entry["source_code"]}))
+
+    return (response["name"], source_files)
+
+
 def get_contract_from_explorer(token, explorer_hostname, contract):
     if explorer_hostname.startswith("zksync"):
         return _get_contract_from_zksync(explorer_hostname, contract)
@@ -84,4 +100,6 @@ def get_contract_from_explorer(token, explorer_hostname, contract):
         return _get_contract_from_mantle(explorer_hostname, contract)
     if explorer_hostname.endswith("lineascan.build"):
         return _get_contract_from_etherscan(None, explorer_hostname, contract)
+    if explorer_hostname.endswith("metisdevops.link"):
+        return _get_contract_from_metis(explorer_hostname, contract)
     return _get_contract_from_etherscan(token, explorer_hostname, contract)


### PR DESCRIPTION
- [x] add wstETH on Metis Sepolia deployments
- [x] add support for the Metis blockscan, [API](https://sepolia-explorer.metisdevops.link/api-docs)