### PR TITLE
Cfg: add wstETH on BSC configs

### DIFF
--- a/config_samples/bsc/mainnet/lido_adi_mainnet_config_binance.json
+++ b/config_samples/bsc/mainnet/lido_adi_mainnet_config_binance.json
@@ -10,7 +10,7 @@
     "0xc934433f4c433Cf80DE6fB65fd70C7a650D8a408": "LayerZeroAdapter",
     "0xBb1E43408BbF2C767Ff3Bd5bBC34E183CC1Ef119": "WormholeAdapter"
   },
-  "explorer_token_env_var": "ETHERSCAN_API_BINANCE",
+  "explorer_token_env_var": "BSCSCAN_TOKEN",
   "explorer_hostname": "api.bscscan.com",
   "github_repo": {
     "url": "https://github.com/lidofinance/aave-delivery-infrastructure",

--- a/config_samples/bsc/mainnet/lido_adi_mainnet_config_ethereum.json
+++ b/config_samples/bsc/mainnet/lido_adi_mainnet_config_ethereum.json
@@ -8,7 +8,7 @@
     "0x742650E0441Be8503682965d601AD0Ba1fB54411": "LayerZeroAdapter",
     "0xEDc0D2cb2289BBa1587424dd42bDD1ca7eAbDF17": "WormholeAdapter"
   },
-  "explorer_token_env_var": "ETHERSCAN_API_MAINNET",
+  "explorer_token_env_var": "ETHERSCAN_TOKEN",
   "explorer_hostname": "api.etherscan.io",
   "github_repo": {
     "url": "https://github.com/lidofinance/aave-delivery-infrastructure",

--- a/config_samples/bsc/mainnet/wsteth_mainnet_config_binance.json
+++ b/config_samples/bsc/mainnet/wsteth_mainnet_config_binance.json
@@ -8,6 +8,7 @@
   },
   "explorer_token_env_var": "BSCSCAN_TOKEN",
   "explorer_hostname": "api.bscscan.com",
+  "audit_url": "https://github.com/wormhole-foundation/wormhole-audits/blob/main/2024-07-23-cyfrin-wormhole-evm-ntt-diff-v1.1.0.pdf",
   "github_repo": {
     "url": "https://github.com/wormhole-foundation/example-native-token-transfers",
     "commit": "0d37b0f4975084492c72ca881c1218d6e1aae9e3",

--- a/config_samples/bsc/mainnet/wsteth_mainnet_config_binance.json
+++ b/config_samples/bsc/mainnet/wsteth_mainnet_config_binance.json
@@ -1,0 +1,28 @@
+{
+  "contracts": {
+    "0x6981F5621691CBfE3DdD524dE71076b79F0A0278": "ERC1967Proxy",
+    "0xe82c2a5846cfb6d8683d6b636719e7aa61486838": "NttManager",
+    "0xbe3F7e06872E0dF6CD7FF35B7aa4Bb1446DC9986": "ERC1967Proxy",
+    "0xb948a93827d68a82F6513Ad178964Da487fe2BD9": "WormholeTransceiver",
+    "0xf0396a8077eda579f657B5E6F3c3F5e8EE81972b": "TransceiverStructs"
+  },
+  "explorer_token_env_var": "BSCSCAN_TOKEN",
+  "explorer_hostname": "api.bscscan.com",
+  "github_repo": {
+    "url": "https://github.com/wormhole-foundation/example-native-token-transfers",
+    "commit": "0d37b0f4975084492c72ca881c1218d6e1aae9e3",
+    "relative_root": "evm"
+  },
+  "dependencies": {
+    "lib/openzeppelin-contracts": {
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts",
+      "commit": "0457042d93d9dfd760dbaa06a4d2f1216fdbe297",
+      "relative_root": ""
+    },
+    "lib/wormhole-solidity-sdk": {
+      "url": "https://github.com/wormhole-foundation/wormhole-solidity-sdk",
+      "commit": "b9e129e65d34827d92fceeed8c87d3ecdfc801d0",
+      "relative_root": ""
+    }
+  }
+}

--- a/config_samples/bsc/mainnet/wsteth_mainnet_config_binance_token.json
+++ b/config_samples/bsc/mainnet/wsteth_mainnet_config_binance_token.json
@@ -5,6 +5,7 @@
   },
   "explorer_token_env_var": "BSCSCAN_TOKEN",
   "explorer_hostname": "api.bscscan.com",
+  "audit_url": "https://github.com/wormhole-foundation/example-wormhole-axelar-wsteth/blob/main/audits/2024-06-10-cyfrin-audit-2024-06-wormhole-axelar-wsteth-l2token.pdf",
   "github_repo": {
     "url": "https://github.com/wormhole-foundation/example-wormhole-axelar-wsteth",
     "commit": "eae15a0dd4a55481c8bf776c250d86bf0529a061",

--- a/config_samples/bsc/mainnet/wsteth_mainnet_config_binance_token.json
+++ b/config_samples/bsc/mainnet/wsteth_mainnet_config_binance_token.json
@@ -1,0 +1,30 @@
+{
+  "contracts": {
+    "0x26c5e01524d2E6280A48F2c50fF6De7e52E9611C": "ERC1967Proxy",
+    "0x451d447776778870bdfe76d031689703aba73ee5": "WstEthL2Token"
+  },
+  "explorer_token_env_var": "BSCSCAN_TOKEN",
+  "explorer_hostname": "api.bscscan.com",
+  "github_repo": {
+    "url": "https://github.com/wormhole-foundation/example-wormhole-axelar-wsteth",
+    "commit": "eae15a0dd4a55481c8bf776c250d86bf0529a061",
+    "relative_root": ""
+  },
+  "dependencies": {
+    "lib/openzeppelin-contracts-upgradeable": {
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable",
+      "commit": "723f8cab09cdae1aca9ec9cc1cfa040c2d4b06c1",
+      "relative_root": ""
+    },
+    "lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts": {
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts",
+      "commit": "dbb6104ce834628e473d2173bbc9d47f81a9eec3",
+      "relative_root": ""
+    },
+    "lib/example-native-token-transfers": {
+      "url": "https://github.com/wormhole-foundation/example-native-token-transfers",
+      "commit": "0d37b0f4975084492c72ca881c1218d6e1aae9e3",
+      "relative_root": ""
+    }
+  }
+}

--- a/config_samples/bsc/mainnet/wsteth_mainnet_config_ethereum.json
+++ b/config_samples/bsc/mainnet/wsteth_mainnet_config_ethereum.json
@@ -8,6 +8,7 @@
   },
   "explorer_token_env_var": "ETHERSCAN_TOKEN",
   "explorer_hostname": "api.etherscan.io",
+  "audit_url": "https://github.com/wormhole-foundation/wormhole-audits/blob/main/2024-07-23-cyfrin-wormhole-evm-ntt-diff-v1.1.0.pdf",
   "github_repo": {
     "url": "https://github.com/wormhole-foundation/example-native-token-transfers",
     "commit": "0d37b0f4975084492c72ca881c1218d6e1aae9e3",

--- a/config_samples/bsc/mainnet/wsteth_mainnet_config_ethereum.json
+++ b/config_samples/bsc/mainnet/wsteth_mainnet_config_ethereum.json
@@ -1,0 +1,28 @@
+{
+  "contracts": {
+    "0xb948a93827d68a82F6513Ad178964Da487fe2BD9": "ERC1967Proxy",
+    "0xc6c1f091450b54af3280cfed790047431bc99bb1": "NttManager",
+    "0xA1ACC1e6edaB281Febd91E3515093F1DE81F25c0": "ERC1967Proxy",
+    "0x3ce1230f39302e62b67bbf2316558f79c25424a2": "WormholeTransceiver",
+    "0xf0396a8077eda579f657B5E6F3c3F5e8EE81972b": "TransceiverStructs"
+  },
+  "explorer_token_env_var": "ETHERSCAN_TOKEN",
+  "explorer_hostname": "api.etherscan.io",
+  "github_repo": {
+    "url": "https://github.com/wormhole-foundation/example-native-token-transfers",
+    "commit": "0d37b0f4975084492c72ca881c1218d6e1aae9e3",
+    "relative_root": "evm"
+  },
+  "dependencies": {
+    "lib/openzeppelin-contracts": {
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts",
+      "commit": "0457042d93d9dfd760dbaa06a4d2f1216fdbe297",
+      "relative_root": ""
+    },
+    "lib/wormhole-solidity-sdk": {
+      "url": "https://github.com/wormhole-foundation/wormhole-solidity-sdk",
+      "commit": "b9e129e65d34827d92fceeed8c87d3ecdfc801d0",
+      "relative_root": ""
+    }
+  }
+}

--- a/config_samples/bsc/testnet/lido_adi_testnet_config_binance.json
+++ b/config_samples/bsc/testnet/lido_adi_testnet_config_binance.json
@@ -9,7 +9,7 @@
     "0xa950B68BDA44419683c788C5E5845abC8F1863C1": "LayerZeroAdapterTestnet",
     "0x30dF46cF148Df5eB53eb8B81b0BD5Bc785001E12": "WormholeAdapterTestnet"
   },
-  "explorer_token_env_var": "ETHERSCAN_API_BINANCE",
+  "explorer_token_env_var": "BSCSCAN_TOKEN",
   "explorer_hostname": "api-testnet.bscscan.com",
   "github_repo": {
     "url": "https://github.com/lidofinance/aave-delivery-infrastructure",

--- a/config_samples/bsc/testnet/lido_adi_testnet_config_ethereum.json
+++ b/config_samples/bsc/testnet/lido_adi_testnet_config_ethereum.json
@@ -8,7 +8,7 @@
     "0xFA3199330C9F33e5bA2D559574033D9cf3FCb609": "LayerZeroAdapterTestnet",
     "0x82C16B1e054fa94bf60b54A1Aa9FA74c5872899d": "WormholeAdapterTestnet"
   },
-  "explorer_token_env_var": "ETHERSCAN_API_SEPOLIA",
+  "explorer_token_env_var": "ETHERSCAN_TOKEN",
   "explorer_hostname": "api-sepolia.etherscan.io",
   "github_repo": {
     "url": "https://github.com/lidofinance/aave-delivery-infrastructure",

--- a/config_samples/bsc/testnet/wsteth_testnet_config_binance.json
+++ b/config_samples/bsc/testnet/wsteth_testnet_config_binance.json
@@ -8,6 +8,7 @@
   },
   "explorer_token_env_var": "BSCSCAN_TOKEN",
   "explorer_hostname": "api-testnet.bscscan.com",
+  "audit_url": "https://github.com/wormhole-foundation/wormhole-audits/blob/main/2024-07-23-cyfrin-wormhole-evm-ntt-diff-v1.1.0.pdf",
   "github_repo": {
     "url": "https://github.com/wormhole-foundation/example-native-token-transfers",
     "commit": "0d37b0f4975084492c72ca881c1218d6e1aae9e3",

--- a/config_samples/bsc/testnet/wsteth_testnet_config_binance.json
+++ b/config_samples/bsc/testnet/wsteth_testnet_config_binance.json
@@ -1,0 +1,28 @@
+{
+  "contracts": {
+    "0x66cb5a992570ef01b522bc59a056a64a84bd0aaa": "ERC1967Proxy",
+    "0xa0310f52f4ac9c394a82b2e19267a78d3390a16f": "NttManager",
+    "0x3a84364d27Ed3D16022Da0f603f3E0F74826c707": "ERC1967Proxy",
+    "0xca7cf7369d5206f7a50cccbd85d7672eb86b362c": "WormholeTransceiver",
+    "0xf0396a8077eda579f657B5E6F3c3F5e8EE81972b": "TransceiverStructs"
+  },
+  "explorer_token_env_var": "BSCSCAN_TOKEN",
+  "explorer_hostname": "api-testnet.bscscan.com",
+  "github_repo": {
+    "url": "https://github.com/wormhole-foundation/example-native-token-transfers",
+    "commit": "0d37b0f4975084492c72ca881c1218d6e1aae9e3",
+    "relative_root": "evm"
+  },
+  "dependencies": {
+    "lib/openzeppelin-contracts": {
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts",
+      "commit": "0457042d93d9dfd760dbaa06a4d2f1216fdbe297",
+      "relative_root": ""
+    },
+    "lib/wormhole-solidity-sdk": {
+      "url": "https://github.com/wormhole-foundation/wormhole-solidity-sdk",
+      "commit": "b9e129e65d34827d92fceeed8c87d3ecdfc801d0",
+      "relative_root": ""
+    }
+  }
+}

--- a/config_samples/bsc/testnet/wsteth_testnet_config_binance_token.json
+++ b/config_samples/bsc/testnet/wsteth_testnet_config_binance_token.json
@@ -1,0 +1,30 @@
+{
+  "contracts": {
+    "0x0b15635fcf5316edfd2a9a0b0dc3700aea4d09e6": "ERC1967Proxy",
+    "0x83bc41aae95b447134e72892ba659d6ea664d496": "WstEthL2Token"
+  },
+  "explorer_token_env_var": "BSCSCAN_TOKEN",
+  "explorer_hostname": "api-testnet.bscscan.com",
+  "github_repo": {
+    "url": "https://github.com/wormhole-foundation/example-wormhole-axelar-wsteth",
+    "commit": "eae15a0dd4a55481c8bf776c250d86bf0529a061",
+    "relative_root": ""
+  },
+  "dependencies": {
+    "lib/openzeppelin-contracts-upgradeable": {
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable",
+      "commit": "723f8cab09cdae1aca9ec9cc1cfa040c2d4b06c1",
+      "relative_root": ""
+    },
+    "lib/openzeppelin-contracts": {
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts",
+      "commit": "dbb6104ce834628e473d2173bbc9d47f81a9eec3",
+      "relative_root": ""
+    },
+    "lib/example-native-token-transfers": {
+      "url": "https://github.com/wormhole-foundation/example-native-token-transfers",
+      "commit": "0d37b0f4975084492c72ca881c1218d6e1aae9e3",
+      "relative_root": ""
+    }
+  }
+}

--- a/config_samples/bsc/testnet/wsteth_testnet_config_binance_token.json
+++ b/config_samples/bsc/testnet/wsteth_testnet_config_binance_token.json
@@ -5,6 +5,7 @@
   },
   "explorer_token_env_var": "BSCSCAN_TOKEN",
   "explorer_hostname": "api-testnet.bscscan.com",
+  "audit_url": "https://github.com/wormhole-foundation/example-wormhole-axelar-wsteth/blob/main/audits/2024-06-10-cyfrin-audit-2024-06-wormhole-axelar-wsteth-l2token.pdf",
   "github_repo": {
     "url": "https://github.com/wormhole-foundation/example-wormhole-axelar-wsteth",
     "commit": "eae15a0dd4a55481c8bf776c250d86bf0529a061",

--- a/config_samples/bsc/testnet/wsteth_testnet_config_ethereum.json
+++ b/config_samples/bsc/testnet/wsteth_testnet_config_ethereum.json
@@ -1,0 +1,28 @@
+{
+  "contracts": {
+    "0x8B715EAf61A7DdF61C67d5D46687c796D1f47146": "ERC1967Proxy",
+    "0x607b139bfee21b2676ee664a237a70d737b9466e": "NttManager",
+    "0xF2bc73502283fcaC4b047dfE45366d8744daaC5B": "ERC1967Proxy",
+    "0xaf99eeb712511303f8b829707aafc5881a125771": "WormholeTransceiver",
+    "0xf0396a8077eda579f657B5E6F3c3F5e8EE81972b": "TransceiverStructs"
+  },
+  "explorer_token_env_var": "ETHERSCAN_TOKEN",
+  "explorer_hostname": "api-sepolia.etherscan.io",
+  "github_repo": {
+    "url": "https://github.com/wormhole-foundation/example-native-token-transfers",
+    "commit": "0d37b0f4975084492c72ca881c1218d6e1aae9e3",
+    "relative_root": "evm"
+  },
+  "dependencies": {
+    "lib/openzeppelin-contracts": {
+      "url": "https://github.com/OpenZeppelin/openzeppelin-contracts",
+      "commit": "0457042d93d9dfd760dbaa06a4d2f1216fdbe297",
+      "relative_root": ""
+    },
+    "lib/wormhole-solidity-sdk": {
+      "url": "https://github.com/wormhole-foundation/wormhole-solidity-sdk",
+      "commit": "b9e129e65d34827d92fceeed8c87d3ecdfc801d0",
+      "relative_root": ""
+    }
+  }
+}

--- a/config_samples/bsc/testnet/wsteth_testnet_config_ethereum.json
+++ b/config_samples/bsc/testnet/wsteth_testnet_config_ethereum.json
@@ -8,6 +8,7 @@
   },
   "explorer_token_env_var": "ETHERSCAN_TOKEN",
   "explorer_hostname": "api-sepolia.etherscan.io",
+  "audit_url": "https://github.com/wormhole-foundation/wormhole-audits/blob/main/2024-07-23-cyfrin-wormhole-evm-ntt-diff-v1.1.0.pdf",
   "github_repo": {
     "url": "https://github.com/wormhole-foundation/example-native-token-transfers",
     "commit": "0d37b0f4975084492c72ca881c1218d6e1aae9e3",


### PR DESCRIPTION
- [x] Add [mainnet](
https://research.lido.fi/t/wormhole-x-axelar-lido-bridge-implementation-for-wsteth-on-bnb-chain/6012/31) configs
- [x] Add [testnet](https://research.lido.fi/t/wormhole-x-axelar-lido-bridge-implementation-for-wsteth-on-bnb-chain/6012/32) configs


---

Axelar sources are flattened with Hardhat 2.22.6 so it's impossible to automate the checks at the moment :dagger:  

- Transceiver Structs (used by Axelar Transceiver, Ethreum): [0xa12bc993d8144404a8c8c812816048275a066ced](https://etherscan.io/address/0xa12bc993d8144404a8c8c812816048275a066ced)
- Transceiver Structs (used by Axelar Transceiver, BSC): [0x27a3daf3b243104e9b0afae6b56026a416b852c9](https://bscscan.com/address/0x27a3daf3b243104e9b0afae6b56026a416b852c9)
- Axelar Transceiver (Ethereum): [0x723AEAD29acee7E9281C32D11eA4ed0070c41B13](https://etherscan.io/address/0x723AEAD29acee7E9281C32D11eA4ed0070c41B13) (proxy)
- Axelar Transceiver (Ethereum): [0x87fc4b27385bb4e69a40027931229d74ef4d1943](https://etherscan.io/address/0x87fc4b27385bb4e69a40027931229d74ef4d1943) (impl)
- Axelar Transceiver (BSC): [0x723AEAD29acee7E9281C32D11eA4ed0070c41B13](https://bscscan.com/address/0x723AEAD29acee7E9281C32D11eA4ed0070c41B13) (proxy)
- Axelar Transceiver (BSC): [0xa1ebb6a4b856df8bf6c3aca88a9115a9ab3b2e02](https://bscscan.com/address/0xa1ebb6a4b856df8bf6c3aca88a9115a9ab3b2e02) (impl)