### PR TITLE
Handle calldata for the contracts without constructor

### DIFF
--- a/diffyscan/utils/calldata.py
+++ b/diffyscan/utils/calldata.py
@@ -63,16 +63,21 @@ def parse_calldata_from_config(
     contract_address_from_config, constructor_args, target_compiled_contract
 ):
     logger.info(f"Trying to parse calldata from config")
-    constructor_abi = get_constructor_abi(target_compiled_contract)
-    if constructor_abi is None:
-        raise CalldataError("Failed to find ABI constructor in compiled contract")
 
     if constructor_args is None:
         raise CalldataError("Failed to find constructor's args in config")
 
-    calldata = encode_constructor_arguments(
-        constructor_abi, constructor_args[contract_address_from_config]
-    )
+    constructor_abi = get_constructor_abi(target_compiled_contract)
+    constructor_config_args = constructor_args[contract_address_from_config]
+
+    if constructor_abi is None:
+        if len(constructor_config_args) > 0:
+            raise CalldataError(
+                f"Constructor args provided for contract without constructor: {contract_address_from_config}"
+            )
+        return ""
+
+    calldata = encode_constructor_arguments(constructor_abi, constructor_config_args)
 
     if not calldata:
         raise CalldataError("Contract calldata is empty")


### PR DESCRIPTION
## Description

If a contract constructor is not explicitly defined, it may also be missing from the contract’s ABI. For example: https://hoodi.etherscan.io/address/0xB26Fd3b50280AbC55c572EE73071778A51088408#code.

Currently, such ABIs are not handled correctly — Diffiscan reverts with an error in this case:

![image](https://github.com/user-attachments/assets/8fd3d05a-3e6d-41c6-88f2-c66a348d345e)

This PR adjusts the behavior to return empty calldata for contracts without a constructor.

## Example configuration to test the fix:

`config_samples/constructor-test-config.json`
```json
{
    "contracts": {
      "0x9CCe5BfAcDcf80DAd2287106b57197284DacaE3F": "DGLaunchRolesValidatorHoodi",
      "0xB26Fd3b50280AbC55c572EE73071778A51088408": "TimeConstraints"
    },
    "explorer_hostname": "api-hoodi.etherscan.io",
    "github_repo": {
      "url": "https://github.com/lidofinance/dual-governance",
      "commit": "c5726f98a1cb4936a3589892cda01826fd959e2b",
      "relative_root": ""
    },
    "dependencies": {
      "lib/openzeppelin-contracts/contracts": {
        "url": "https://github.com/OpenZeppelin/openzeppelin-contracts",
        "commit": "dbb6104ce834628e473d2173bbc9d47f81a9eec3",
        "relative_root": "contracts"
      }
    },
    "fail_on_comparison_error": false,
    "bytecode_comparison": {
      "hardhat_config_name": "hardhat.config.js",
      "constructor_args": {
        "0x9CCe5BfAcDcf80DAd2287106b57197284DacaE3F": [
          "0x0eCc17597D292271836691358B22340b78F3035B",
          "0x05172CbCDb7307228F781436b327679e4DAE166B"
        ],
        "0xB26Fd3b50280AbC55c572EE73071778A51088408": []
      }
    }
  }
```

`hardhat_config.json`
```js
module.exports = {
    solidity: "0.8.26",
    networks: {
        hardhat: {
            chainId: 560048,
            blockGasLimit: 36000000,
            hardfork: "cancun",
        },
    },
};
```