### PR TITLE
fix: remove Etherscan API key from logs

### DIFF
--- a/diffyscan/utils/common.py
+++ b/diffyscan/utils/common.py
@@ -36,7 +36,7 @@ def load_config(path: str) -> Config:
 
 
 def fetch(url, headers=None):
-    logger.log(f"Fetch: {url}")
+    logger.log(f"Fetch: {mask_text(url)}")
     try:
         response = requests.get(url, headers=headers)
         response.raise_for_status()


### PR DESCRIPTION
AS IS:
![image](https://github.com/user-attachments/assets/e16f3693-15e3-4533-a424-e4fe6326f56b)
TO BE:
![image](https://github.com/user-attachments/assets/8eb6a6eb-38b1-440e-84ea-8ec93ae59787)
