### PR TITLE
Fix typo in deploy_contract error message

### DIFF
--- a/diffyscan/utils/node_handler.py
+++ b/diffyscan/utils/node_handler.py
@@ -85,7 +85,7 @@ def deploy_contract(rpc_url, deployer, data):
     if response_getTransactionReceipt["result"]["status"] != "0x1":
         raise NodeError(
             "Failed to receive transaction receipt. \
-  Transaction has been reverted (status 0x0). Input missmatch?",
+  Transaction has been reverted (status 0x0). Input mismatch?",
         )
 
     contract_address = response_getTransactionReceipt["result"]["contractAddress"]


### PR DESCRIPTION
## Summary
- fix a typo in `deploy_contract` error message

## Testing
- `black diffyscan/utils/node_handler.py`
- `pytest -q` *(fails: command not found)*