### PR TITLE
Add basic test for is_standard_json_contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ termtables = "^0.2.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"
+pytest = "^7.4.3"
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+CONFIG_DIR = Path('config_samples')
+REQUIRED_GITHUB_KEYS = {'url', 'commit', 'relative_root'}
+
+
+def config_paths():
+    return [p for p in CONFIG_DIR.rglob('*.json')]
+
+
+def load(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def test_config_fields_present():
+    for path in config_paths():
+        cfg = load(path)
+        assert 'contracts' in cfg and cfg['contracts'], f"{path} missing contracts"
+        assert 'github_repo' in cfg
+        assert REQUIRED_GITHUB_KEYS <= set(cfg['github_repo']), f"{path} github_repo keys"
+        assert 'dependencies' in cfg
+        assert 'explorer_hostname' in cfg or 'explorer_hostname_env_var' in cfg
+
+
+def test_contract_addresses_format():
+    for path in config_paths():
+        cfg = load(path)
+        for addr in cfg.get('contracts', {}):
+            assert addr.startswith('0x') and len(addr) == 42, f"Bad addr {addr} in {path}"

--- a/tests/test_explorer_utils.py
+++ b/tests/test_explorer_utils.py
@@ -1,0 +1,13 @@
+import os
+from diffyscan.utils.explorer import get_explorer_hostname
+
+
+def test_get_explorer_hostname_env(monkeypatch):
+    monkeypatch.setenv('MYHOST', 'example.com')
+    cfg = {'explorer_hostname_env_var': 'MYHOST'}
+    assert get_explorer_hostname(cfg) == 'example.com'
+
+
+def test_get_explorer_hostname_direct():
+    cfg = {'explorer_hostname': 'api.etherscan.io'}
+    assert get_explorer_hostname(cfg) == 'api.etherscan.io'

--- a/tests/test_github_utils.py
+++ b/tests/test_github_utils.py
@@ -1,0 +1,26 @@
+from diffyscan.utils.github import (
+    get_github_api_url,
+    path_to_file_without_dependency,
+    resolve_dep,
+)
+
+
+def test_get_github_api_url():
+    url = get_github_api_url('user/repo', 'src', 'file.sol', 'abc123')
+    assert url == 'https://api.github.com/repos/user/repo/contents/src/file.sol?ref=abc123'
+
+
+def test_path_to_file_without_dependency():
+    result = path_to_file_without_dependency('@oz/contracts/token.sol', '@oz/contracts')
+    assert result == 'token.sol'
+
+
+def test_resolve_dep():
+    cfg = {
+        'dependencies': {
+            '@oz/contracts': {'url': 'u', 'commit': 'c', 'relative_root': ''}
+        }
+    }
+    repo, dep_name = resolve_dep('@oz/contracts/token.sol', cfg)
+    assert dep_name == '@oz/contracts'
+    assert repo['commit'] == 'c'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+import pytest
+
+from diffyscan.diffyscan import is_standard_json_contract
+
+
+def test_single_file_format():
+    source_files = {"Contract": {"content": "contract C {}"}}
+    assert not is_standard_json_contract(source_files)
+
+
+def test_standard_json_format():
+    source_files = {
+        "src/Contract.sol": {"content": "contract C {}"},
+        "src/Dependency.sol": {"content": "contract D {}"},
+    }
+    assert is_standard_json_contract(source_files)


### PR DESCRIPTION
## Summary
- add pytest dependency
- add tests for `is_standard_json_contract`
- add more tests covering config fields and utilities

## Testing
- `pytest -q` *(fails: command not found)*