### PR TITLE
Add CLAUDE.md and Claude Code skills

### DIFF
--- a/.claude/skills/add-explorer/SKILL.md
+++ b/.claude/skills/add-explorer/SKILL.md
@@ -72,6 +72,7 @@ Handles both Etherscan v2 and legacy Etherscan APIs.
 - No API token needed
 - Response: `{"verifiedAt": ..., "request": {"ContractName": ..., "CompilerVersion": ..., "sourceCode": {"sources": ...}}}`
 - Returns a minimal contract dict with `name`, `sources`, `compiler` -- does NOT go through `_build_contract_payload` or `_attach_contract_metadata`
+- **Outlier:** Unlike the other fetchers, this does not return `solcInput`. Downstream code (`run_source_diff`, `run_bytecode_diff`) expects `contract["solcInput"]`, so zkSync contracts use a different code path. New fetchers should follow the standard shape returned by `_build_contract_payload` (`name`, `compiler`, `solcInput`, plus optional `constructor_arguments`, `evm_version`, `libraries`).
 
 ### Fetcher 4: `_get_contract_from_mantle(hostname, address)`
 

--- a/.claude/skills/add-explorer/SKILL.md
+++ b/.claude/skills/add-explorer/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: add-explorer
+description: Add support for a new blockchain explorer API to diffyscan. Use when a new chain or explorer type needs to be supported.
+disable-model-invocation: true
+argument-hint: [explorer-name]
+---
+
+Guide through adding support for a new blockchain explorer to diffyscan.
+
+## Architecture context
+
+Explorer support lives in `diffyscan/utils/explorer.py`. The module handles multiple explorer API flavors:
+
+1. **Etherscan-compatible** (most common) — standard `module=contract&action=getsourcecode` API
+2. **Blockscout** — similar API but uses `chain_id` parameter and different response structure
+3. **zkSync block-explorer-api** — different endpoint structure entirely
+4. **Mantle** — Etherscan-compatible with minor differences
+
+## Key functions to modify
+
+1. **`get_contract_from_explorer()`** — main entry point that dispatches to the right fetcher based on hostname
+2. **Response parsing** — each explorer type may return source code in different formats (standard JSON, single file, multi-file)
+3. **`get_explorer_hostname()` / `get_explorer_chain_id()`** in the same module — may need hostname pattern matching
+
+## Steps to add a new explorer
+
+1. **Determine API compatibility**: Most EVM explorers are Etherscan-compatible. Check the explorer's API docs.
+
+2. **If Etherscan-compatible**: Usually just need to:
+   - Add the hostname to config samples
+   - Test that existing parsing works
+   - Add a sample config in `config_samples/<chain>/`
+
+3. **If different API**: Need to:
+   - Add detection logic in `get_contract_from_explorer()` (typically hostname-based)
+   - Implement a new fetch function following existing patterns
+   - Handle response format differences in source parsing
+   - Add tests in `tests/test_explorer_utils.py`
+
+4. **Add a config sample** in `config_samples/<chain>/` with the new explorer
+
+## Testing
+
+- Add unit tests for any new parsing logic in `tests/test_explorer_utils.py`
+- Add a regression config in `config_samples/` for CI
+- Test with `uv run diffyscan <config> --yes --cache-explorer`
+
+## Checklist
+- [ ] Explorer API response format understood
+- [ ] Detection/dispatch logic added if needed
+- [ ] Source code parsing handles the new format
+- [ ] Constructor args / EVM version extraction works
+- [ ] Config sample created
+- [ ] Tests added
+- [ ] `.env.example` updated with new token env var if needed

--- a/.claude/skills/add-explorer/SKILL.md
+++ b/.claude/skills/add-explorer/SKILL.md
@@ -7,49 +7,144 @@ argument-hint: [explorer-name]
 
 Guide through adding support for a new blockchain explorer to diffyscan.
 
-## Architecture context
+## Decision tree: do you need code changes?
 
-Explorer support lives in `diffyscan/utils/explorer.py`. The module handles multiple explorer API flavors:
+Most new chains need NO code changes. Work through this list in order:
 
-1. **Etherscan-compatible** (most common) — standard `module=contract&action=getsourcecode` API
-2. **Blockscout** — similar API but uses `chain_id` parameter and different response structure
-3. **zkSync block-explorer-api** — different endpoint structure entirely
-4. **Mantle** — Etherscan-compatible with minor differences
+1. **Etherscan v2 API (preferred)** -- If the chain is listed on Etherscan's v2 supported chains, create a config with `"explorer_hostname": "api.etherscan.io"` and `"explorer_chain_id": <chain-id>`. Done. No code changes. This uses the endpoint `https://api.etherscan.io/v2/api?chainid=<id>&module=contract&action=getsourcecode&address=<addr>`.
 
-## Key functions to modify
+2. **Legacy Etherscan-compatible hostname** -- If the chain has its own Etherscan-style API (e.g. `api.basescan.org`, `api-optimistic.etherscan.io`), create a config with just `"explorer_hostname"` (no `explorer_chain_id`). The default fetcher handles it. No code changes.
 
-1. **`get_contract_from_explorer()`** — main entry point that dispatches to the right fetcher based on hostname
-2. **Response parsing** — each explorer type may return source code in different formats (standard JSON, single file, multi-file)
-3. **`get_explorer_hostname()` / `get_explorer_chain_id()`** in the same module — may need hostname pattern matching
+3. **Existing Blockscout domain** -- If the chain uses a Blockscout instance whose domain already ends with one of the recognized suffixes (see dispatcher below), create a config with that hostname. No code changes.
 
-## Steps to add a new explorer
+4. **New Blockscout domain** -- If the chain uses Blockscout but with an unrecognized domain, add the domain suffix to `_get_explorer_fetcher()`. One-line change.
 
-1. **Determine API compatibility**: Most EVM explorers are Etherscan-compatible. Check the explorer's API docs.
+5. **Entirely new API format** -- Only if the explorer has a non-Etherscan, non-Blockscout API do you need a new fetcher function.
 
-2. **If Etherscan-compatible**: Usually just need to:
-   - Add the hostname to config samples
-   - Test that existing parsing works
-   - Add a sample config in `config_samples/<chain>/`
+## Architecture: `diffyscan/utils/explorer.py`
 
-3. **If different API**: Need to:
-   - Add detection logic in `get_contract_from_explorer()` (typically hostname-based)
-   - Implement a new fetch function following existing patterns
-   - Handle response format differences in source parsing
-   - Add tests in `tests/test_explorer_utils.py`
+All explorer logic lives in one file. The call flow is:
 
-4. **Add a config sample** in `config_samples/<chain>/` with the new explorer
+```
+get_contract_from_explorer()          # public entry point, handles caching
+  -> _get_explorer_fetcher()          # dispatcher: hostname -> (fetcher_fn, requires_token)
+  -> fetcher(...)                     # one of the four fetchers below
+  -> _validate_contract_name()        # verify name matches config
+```
+
+### The dispatcher: `_get_explorer_fetcher(explorer_hostname)`
+
+This function maps hostnames to fetcher functions using prefix/suffix matching. It returns a tuple of `(fetcher_function, requires_token: bool)`.
+
+Current routing rules (checked in order):
+
+| Condition | Fetcher | Token required? |
+|---|---|---|
+| `hostname.startswith("zksync")` | `_get_contract_from_zksync` | No |
+| `hostname.endswith("mantle.xyz")` | `_get_contract_from_mantle` | No |
+| `hostname.endswith("lineascan.build")` | `_get_contract_from_etherscan` (token forced to `None`) | No |
+| `hostname.endswith(...)` any of: `mode.network`, `blockscout.com`, `swellnetwork.io`, `lisk.com`, `inkonchain.com`, `routescan.io`, `monadvision.com` | `_get_contract_from_blockscout` | No |
+| **Default (everything else)** | `_get_contract_from_etherscan` | **Yes** |
+
+When `requires_token` is True, the caller passes `(token, hostname, address, chain_id)`. When False, the caller passes `(hostname, address)` only.
+
+### Fetcher 1: `_get_contract_from_etherscan(token, hostname, address, chain_id=None)`
+
+Handles both Etherscan v2 and legacy Etherscan APIs.
+
+- **v2 endpoint** (when `chain_id` is set): `https://{hostname}/v2/api?chainid={chain_id}&module=contract&action=getsourcecode&address={address}&apikey={token}`
+- **Legacy endpoint** (when `chain_id` is None): `https://{hostname}/api?module=contract&action=getsourcecode&address={address}&apikey={token}`
+- Has built-in rate-limit retry logic (up to 5 retries with linear backoff)
+- Response format: `{"message": "OK", "result": [{"ContractName": ..., "SourceCode": ..., "CompilerVersion": ..., ...}]}`
+- If `SourceCode` starts with `{{`, it is treated as a JSON solc standard input (stripped of outer braces and parsed)
+- Otherwise, `_build_source_files()` + `_build_solc_input()` construct the solc input from flat source
+
+### Fetcher 2: `_get_contract_from_blockscout(hostname, address)`
+
+- Endpoint: `https://{hostname}/api/v2/smart-contracts/{address}`
+- No API token needed
+- Response is a flat JSON object with fields: `name`, `file_path`, `source_code`, `additional_sources` (list of `{file_path, source_code}`), `compiler_version`, `compiler_settings`, `optimization_enabled`, `optimization_runs`, `constructor_args`, `evm_version`, `external_libraries` (list of `{name, address, ...}`)
+- Note: the response uses both `optimization_runs` and `optimizations_runs` (typo in some Blockscout versions); the code checks both
+
+### Fetcher 3: `_get_contract_from_zksync(hostname, address)`
+
+- Endpoint: `https://{hostname}/contract_verification/info/{address}`
+- No API token needed
+- Response: `{"verifiedAt": ..., "request": {"ContractName": ..., "CompilerVersion": ..., "sourceCode": {"sources": ...}}}`
+- Returns a minimal contract dict with `name`, `sources`, `compiler` -- does NOT go through `_build_contract_payload` or `_attach_contract_metadata`
+
+### Fetcher 4: `_get_contract_from_mantle(hostname, address)`
+
+- Endpoint: `https://{hostname}/api?module=contract&action=getsourcecode&address={address}`
+- No API token needed
+- Etherscan-like response but uses `FileName` (not `ContractName`) as primary path, and `AdditionalSources` list uses `Filename`/`SourceCode` keys (note capitalization differences)
+
+## Shared helpers
+
+- **`_build_source_files(primary_path, primary_source, additional_sources, *, path_key, content_key)`** -- Assembles a `{path: {"content": source}}` dict. The `path_key` and `content_key` parameters handle the field name differences between explorers.
+- **`_build_solc_input(source_files, *, optimizer_enabled, optimizer_runs, settings=None)`** -- Wraps source files into a standard solc JSON input with optimizer config and output selection.
+- **`_build_contract_payload(name, compiler, solc_input, *, constructor_arguments, evm_version, libraries)`** -- Assembles the final contract dict and calls `_attach_contract_metadata()`.
+- **`_attach_contract_metadata(contract, source_files, constructor_arguments, evm_version, libraries)`** -- Normalizes and attaches constructor args (hex string without 0x prefix), EVM version (None if "default"), and libraries (resolved to `{path: {name: address}}` format). Libraries can come from explorer response OR from `solcInput.settings.libraries`; both are merged.
+
+## Steps: adding a new Etherscan v2 chain (no code changes)
+
+1. Find the chain ID (e.g. from chainlist.org)
+2. Create `config_samples/<chain>/<config>.json`:
+   ```json
+   {
+     "contracts": { ... },
+     "explorer_hostname": "api.etherscan.io",
+     "explorer_token_env_var": "ETHERSCAN_EXPLORER_TOKEN",
+     "explorer_chain_id": <chain-id>,
+     "github_repo": { ... }
+   }
+   ```
+3. Test: `uv run diffyscan <config> --yes --cache-explorer`
+
+## Steps: adding a new Blockscout domain
+
+1. Add the domain suffix to the tuple in `_get_explorer_fetcher()` in `diffyscan/utils/explorer.py` (the `any(explorer_hostname.endswith(domain) for domain in [...])` block)
+2. Create a config with `"explorer_hostname": "<blockscout-hostname>"`
+3. Test: `uv run diffyscan <config> --yes --cache-explorer`
+
+## Steps: adding a completely new explorer type
+
+1. **Understand the API**: Document the endpoint URL, response shape, and which fields map to contract name, source code, compiler version, optimizer settings, constructor args, EVM version, and libraries.
+
+2. **Add hostname detection** in `_get_explorer_fetcher()`: Add a new `elif` branch with `startswith()` or `endswith()` matching. Return `(your_fetcher, False)` -- most non-Etherscan explorers do not use API tokens.
+
+3. **Implement the fetcher** `_get_contract_from_<name>(hostname, address)`:
+   - Call the explorer API via `fetch(url).json()`
+   - Validate response (check for verification status, required fields)
+   - Use `_build_source_files()` to assemble sources (pass the correct `path_key`/`content_key` for the response format)
+   - Use `_build_solc_input()` to wrap into solc input
+   - Return via `_build_contract_payload()` to get normalized metadata
+   - If the fetcher does not need a token, its signature should be `(hostname, address)` (two args). If it does need a token, use `(token, hostname, address, chain_id=None)` (four args) and set `requires_token=True` in the dispatcher.
+
+4. **Add tests** in `tests/test_explorer_utils.py` -- follow the existing pattern: monkeypatch `fetch` to return a `DummyResponse`, call `get_contract_from_explorer()`, assert the result.
+
+5. **Add a config sample** in `config_samples/<chain>/`.
+
+## Config fields reference
+
+| Field | Required | Description |
+|---|---|---|
+| `explorer_hostname` | Yes | API hostname (e.g. `api.etherscan.io`, `explorer.mode.network`) |
+| `explorer_chain_id` | No | Chain ID for Etherscan v2 API; omit for legacy or non-Etherscan explorers |
+| `explorer_token_env_var` | No | Env var name holding the API key (e.g. `ETHERSCAN_EXPLORER_TOKEN`) |
 
 ## Testing
 
-- Add unit tests for any new parsing logic in `tests/test_explorer_utils.py`
-- Add a regression config in `config_samples/` for CI
-- Test with `uv run diffyscan <config> --yes --cache-explorer`
+- Unit tests: `tests/test_explorer_utils.py` -- monkeypatch `diffyscan.utils.explorer.fetch` and `CACHE_DIR`
+- Integration: `uv run diffyscan <config> --yes --cache-explorer`
+- The `--cache-explorer` flag caches responses to `.diffyscan_cache/` so repeated runs do not hit the API
 
 ## Checklist
-- [ ] Explorer API response format understood
-- [ ] Detection/dispatch logic added if needed
-- [ ] Source code parsing handles the new format
-- [ ] Constructor args / EVM version extraction works
-- [ ] Config sample created
-- [ ] Tests added
-- [ ] `.env.example` updated with new token env var if needed
+
+- [ ] Determined whether code changes are actually needed (most chains: no)
+- [ ] If Etherscan v2: config-only with `explorer_hostname` + `explorer_chain_id`
+- [ ] If new Blockscout domain: added suffix to `_get_explorer_fetcher()` tuple
+- [ ] If new API type: implemented fetcher, added dispatcher rule, used shared helpers
+- [ ] Config sample created in `config_samples/<chain>/`
+- [ ] Tests added in `tests/test_explorer_utils.py`
+- [ ] `.env.example` updated if a new token env var is needed

--- a/.claude/skills/add-explorer/SKILL.md
+++ b/.claude/skills/add-explorer/SKILL.md
@@ -58,6 +58,7 @@ Handles both Etherscan v2 and legacy Etherscan APIs.
 - Response format: `{"message": "OK", "result": [{"ContractName": ..., "SourceCode": ..., "CompilerVersion": ..., ...}]}`
 - If `SourceCode` starts with `{{`, it is treated as a JSON solc standard input (stripped of outer braces and parsed)
 - Otherwise, `_build_source_files()` + `_build_solc_input()` construct the solc input from flat source
+- **Limitation:** Flattened (single-file) contracts and contracts verified without standard JSON input may produce incomplete solc inputs. The flat-source path creates a minimal solc input from the single source file plus any `AdditionalSources`, but without the original compiler settings (e.g. remappings, via-IR). This can cause bytecode mismatches even when source diffs are clean.
 
 ### Fetcher 2: `_get_contract_from_blockscout(hostname, address)`
 

--- a/.claude/skills/debug-diff/SKILL.md
+++ b/.claude/skills/debug-diff/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: debug-diff
+description: Debug a failed diffyscan verification run. Analyzes diffs, identifies root causes, and suggests fixes. Use when diffyscan exits with non-zero or shows unexpected diffs.
+argument-hint: [config-path-or-contract-address]
+---
+
+Help debug a failed diffyscan verification. The user may provide a config path, contract address, or describe the failure.
+
+## Diagnostic steps
+
+### 1. Check the digest output
+Look in the most recent `digest/` subdirectory for:
+- `logs.txt` — full run log
+- `<address>/*.html` — source diff HTML reports
+
+```bash
+ls -lt digest/ | head -5
+```
+
+### 2. Identify the type of failure
+
+**Source code diffs** — files differ between GitHub and explorer:
+- Check if the GitHub commit in the config matches what was actually deployed
+- Check if `relative_root` is correct (sources may be in a subdirectory)
+- Check if dependencies have the right commits
+- Look for import path mismatches (flat vs nested paths — may need `--support-brownie`)
+- Check for compiler-injected metadata differences (shouldn't appear in source, but sometimes explorers normalize whitespace)
+
+**Bytecode diffs** — compiled bytecode doesn't match on-chain:
+- Missing or wrong `constructor_calldata` / `constructor_args`
+- Missing libraries — check if the contract uses external libraries that need addresses in `bytecode_comparison.libraries`
+- Wrong EVM version — the explorer may report a different version than expected
+- Immutable variables — `deep_match_bytecode` should handle these, but complex immutables may fail
+- Optimizer settings mismatch — the solc input from the explorer includes optimizer settings
+
+**Compilation errors**:
+- Missing GitHub sources — dependency not configured or wrong `relative_root`
+- Solc version mismatch — check that the compiler version exists for the platform
+
+**Network/API errors**:
+- Explorer API rate limiting — try `--cache-explorer` to reuse cached responses
+- RPC errors — check `REMOTE_RPC_URL` is valid and supports `eth_call`
+
+### 3. Common fixes
+
+| Symptom | Likely fix |
+|---------|-----------|
+| "missing GitHub sources" | Add missing dependency to `dependencies` in config |
+| Source diffs in OZ imports | Check dependency commit hash matches |
+| Bytecode mismatch after constructor | Add `constructor_args` or `constructor_calldata` for the contract |
+| "library not found" | Add library addresses to `bytecode_comparison.libraries` |
+| All files show diffs | Wrong `commit` or `relative_root` in `github_repo` |
+| Single contract fails | May need per-contract `constructor_calldata` entry |
+
+### 4. Suggest a re-run command
+After fixing, suggest:
+```bash
+uv run diffyscan <config-path> --yes --cache-explorer --cache-github
+```
+
+Use `--cache-explorer` and `--cache-github` to avoid re-fetching unchanged data.
+Use `--allow-source-diff 0xAddr` or `--allow-bytecode-diff 0xAddr` for known acceptable diffs.

--- a/.claude/skills/debug-diff/SKILL.md
+++ b/.claude/skills/debug-diff/SKILL.md
@@ -64,7 +64,7 @@ ls digest/<timestamp>/diffs/<contract_address>/
 | `"missing GitHub sources for bytecode compilation"` | Add the missing dependency to `dependencies` in the config with correct `url`, `commit`, and `relative_root` |
 | Source diffs in OpenZeppelin or other dependency imports | Check the dependency `commit` hash matches what was used at deploy time |
 | Bytecode mismatch after constructor | Add `constructor_calldata` (raw hex) or `constructor_args` (ABI-typed values) for the contract under `bytecode_comparison` |
-| `"Failed to infer source path for library"` | Add library addresses to `bytecode_comparison.libraries` keyed by `"path/to/File.sol": {"LibName": "0xAddr"}` |
+| `"Failed to infer source path for library '...' from explorer metadata"` | Add library addresses to `bytecode_comparison.libraries` keyed by `"path/to/File.sol": {"LibName": "0xAddr"}` |
 | All files show diffs | Wrong `commit` or `relative_root` in `github_repo` |
 | Single contract fails | May need a per-contract `constructor_calldata` or `constructor_args` entry |
 | `"Bytecodes have differences not on the immutable reference position"` | Real bytecode mismatch -- check compiler version, optimizer settings, EVM version, and library addresses |

--- a/.claude/skills/debug-diff/SKILL.md
+++ b/.claude/skills/debug-diff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug-diff
-description: Debug a failed diffyscan verification run. Analyzes diffs, identifies root causes, and suggests fixes. Use when diffyscan exits with non-zero or shows unexpected diffs.
+description: Debug a failed diffyscan verification run. Analyzes diffs, identifies root causes. Use when diffyscan exits with non-zero or shows unexpected diffs.
 argument-hint: [config-path-or-contract-address]
 ---
 
@@ -80,7 +80,5 @@ uv run diffyscan <config-path> --yes --cache-explorer --cache-github
 - `--cache-explorer` (`-E`) reuses cached explorer responses from `.diffyscan_cache/`
 - `--cache-github` (`-G`) reuses cached GitHub file fetches
 - `--support-brownie` enables recursive retrieval for brownie-verified contracts with flattened import paths
-- `--skip-binary-comparison` (`-S`) skips bytecode comparison entirely (useful when debugging source diffs only)
 - `--allow-source-diff 0xAddr` accepts source diffs for a specific address (can be repeated)
 - `--allow-bytecode-diff 0xAddr` accepts bytecode diffs for a specific address (can be repeated)
-- `--log-level warn` or `--quiet` (`-Q`) reduces output noise

--- a/.claude/skills/debug-diff/SKILL.md
+++ b/.claude/skills/debug-diff/SKILL.md
@@ -43,6 +43,7 @@ ls digest/<timestamp>/diffs/<contract_address>/
 - Wrong EVM version -- the explorer may report a different version than expected
 - Immutable variables -- `deep_match_bytecode()` in `diffyscan/utils/binary_verifier.py` compares instruction-by-instruction and tolerates differences that fall within known immutable reference regions. If all diffs are in immutable positions it logs a warning and returns `False` (still reported as a non-match — use `--allow-bytecode-diff 0xAddr` to accept). Differences outside immutable regions raise `BinVerifierError`
 - Optimizer settings mismatch -- the solcInput from the explorer includes optimizer settings; the GitHub recompilation must match
+- Flat-source contracts -- see **Known limitations** section below
 
 **Compilation errors** (raised as `CompileError`):
 - Missing GitHub sources -- a dependency is not configured or has a wrong `relative_root`. The error message is: `"missing GitHub sources for bytecode compilation; count=N; first=path1, path2..."` (from `run_bytecode_diff()` in `diffyscan/diffyscan.py`)
@@ -82,3 +83,18 @@ uv run diffyscan <config-path> --yes --cache-explorer --cache-github
 - `--support-brownie` enables recursive retrieval for brownie-verified contracts with flattened import paths
 - `--allow-source-diff 0xAddr` accepts source diffs for a specific address (can be repeated)
 - `--allow-bytecode-diff 0xAddr` accepts bytecode diffs for a specific address (can be repeated)
+
+## Known limitations
+
+If any of these apply, **explicitly tell the user** — these are inherent constraints of the tool, not bugs to debug.
+
+### Flat-source (non-standard-JSON) contracts
+
+When a contract was verified on the explorer as a single flattened file (the explorer's `SourceCode` is a plain string, not JSON wrapped in `{{}}`), diffyscan **cannot reliably reproduce the bytecode**. Two problems arise:
+
+1. **Lost compiler settings** — diffyscan reconstructs a minimal solc input with only basic optimizer settings. Remappings, via-IR, and other original compiler settings are not available from the explorer for flat-verified contracts. Bytecode mismatches are **expected** even when source diffs are clean.
+2. **Contract name used as source key** — the explorer's `ContractName` field is used as the solc source file key (e.g. `{"sources": {"MyContract": {...}}}`). If the explorer does not return `ContractName`, or the name does not match the actual `contract` declaration in the Solidity source, the compiled output cannot be remapped and `get_target_compiled_contract()` will fail.
+
+**How to detect**: check the explorer response or logs — if the solc input has a source key that looks like a contract name (no `.sol` extension, no path separators) rather than a file path, the contract was flat-verified.
+
+**What to tell the user**: explain that bytecode comparison is unreliable for this contract due to the flat-source limitation. Recommend using `--allow-bytecode-diff 0xAddr` to accept the mismatch, and note that source comparison is still valid.

--- a/.claude/skills/debug-diff/SKILL.md
+++ b/.claude/skills/debug-diff/SKILL.md
@@ -9,48 +9,66 @@ Help debug a failed diffyscan verification. The user may provide a config path, 
 ## Diagnostic steps
 
 ### 1. Check the digest output
-Look in the most recent `digest/` subdirectory for:
-- `logs.txt` — full run log
-- `<address>/*.html` — source diff HTML reports
+Each run creates a timestamped directory under `digest/`. The timestamp is `int(time.time())` captured at process start (see `diffyscan/utils/constants.py`):
+- `digest/{timestamp}/logs.txt` -- full run log (written by `Logger` in `diffyscan/utils/logger.py`)
+- `digest/{timestamp}/diffs/{contract_address}/{filename}.html` -- per-file HTML source diff reports
 
+Find the most recent run:
 ```bash
-ls -lt digest/ | head -5
+ls -lt digest/ | grep "^d" | head -5
+```
+
+Then inspect its contents:
+```bash
+# View the log
+cat digest/<timestamp>/logs.txt
+
+# List HTML diff reports for a specific contract
+ls digest/<timestamp>/diffs/<contract_address>/
 ```
 
 ### 2. Identify the type of failure
 
-**Source code diffs** — files differ between GitHub and explorer:
-- Check if the GitHub commit in the config matches what was actually deployed
-- Check if `relative_root` is correct (sources may be in a subdirectory)
-- Check if dependencies have the right commits
-- Look for import path mismatches (flat vs nested paths — may need `--support-brownie`)
-- Check for compiler-injected metadata differences (shouldn't appear in source, but sometimes explorers normalize whitespace)
+**Source code diffs** -- files differ between GitHub and the blockchain explorer:
+- Check if the `commit` in `github_repo` matches what was actually deployed
+- Check if `relative_root` is correct (sources may live in a subdirectory of the repo)
+- Check if entries in `dependencies` have the right `commit` hashes and `relative_root` paths
+- Look for import path mismatches (flat vs nested -- may need `--support-brownie` for brownie-verified contracts)
+- Open the HTML diff files (`digest/{timestamp}/diffs/{address}/*.html`) to see exactly which lines differ
+- The report table in logs shows columns: `#`, `Filename`, `Found`, `Diffs`, `Origin`, `Report`
 
-**Bytecode diffs** — compiled bytecode doesn't match on-chain:
-- Missing or wrong `constructor_calldata` / `constructor_args`
-- Missing libraries — check if the contract uses external libraries that need addresses in `bytecode_comparison.libraries`
-- Wrong EVM version — the explorer may report a different version than expected
-- Immutable variables — `deep_match_bytecode` should handle these, but complex immutables may fail
-- Optimizer settings mismatch — the solc input from the explorer includes optimizer settings
+**Bytecode diffs** -- compiled bytecode does not match on-chain:
+- Missing or wrong constructor arguments -- see `constructor_calldata` or `constructor_args` under the `bytecode_comparison` config key
+- Missing libraries -- check if the contract uses external libraries that need addresses in `bytecode_comparison.libraries`
+- Wrong EVM version -- the explorer may report a different version than expected
+- Immutable variables -- `deep_match_bytecode()` in `diffyscan/utils/binary_verifier.py` compares instruction-by-instruction and tolerates differences that fall within known immutable reference regions. If all diffs are in immutable positions it logs a warning and returns `False` (still reported as a non-match — use `--allow-bytecode-diff 0xAddr` to accept). Differences outside immutable regions raise `BinVerifierError`
+- Optimizer settings mismatch -- the solcInput from the explorer includes optimizer settings; the GitHub recompilation must match
 
-**Compilation errors**:
-- Missing GitHub sources — dependency not configured or wrong `relative_root`
-- Solc version mismatch — check that the compiler version exists for the platform
+**Compilation errors** (raised as `CompileError`):
+- Missing GitHub sources -- a dependency is not configured or has a wrong `relative_root`. The error message is: `"missing GitHub sources for bytecode compilation; count=N; first=path1, path2..."` (from `run_bytecode_diff()` in `diffyscan/diffyscan.py`)
+- Solc version mismatch -- check that the compiler version exists for the platform (solc binaries are cached in `~/.cache/diffyscan/solc/` or equivalent via `XDG_CACHE_HOME`)
+
+**Constructor calldata errors** (raised as `CalldataError` from `diffyscan/utils/calldata.py`):
+- `"No constructor calldata found for 0x... (not in config and not in explorer metadata)"` -- need to add `constructor_calldata` or `constructor_args` to the config
+- `"Contract 0x... found in both 'constructor_args' and 'constructor_calldata'"` -- only one should be specified per contract
 
 **Network/API errors**:
-- Explorer API rate limiting — try `--cache-explorer` to reuse cached responses
-- RPC errors — check `REMOTE_RPC_URL` is valid and supports `eth_call`
+- Explorer API rate limiting -- try `--cache-explorer` to reuse cached responses (cached in `.diffyscan_cache/`)
+- RPC errors -- check that `REMOTE_RPC_URL` env var is valid and the node supports `eth_call`
+- Explorer token missing -- the config key `explorer_token_env_var` names the env var holding the API token; if absent, falls back to `ETHERSCAN_EXPLORER_TOKEN`
 
 ### 3. Common fixes
 
 | Symptom | Likely fix |
 |---------|-----------|
-| "missing GitHub sources" | Add missing dependency to `dependencies` in config |
-| Source diffs in OZ imports | Check dependency commit hash matches |
-| Bytecode mismatch after constructor | Add `constructor_args` or `constructor_calldata` for the contract |
-| "library not found" | Add library addresses to `bytecode_comparison.libraries` |
+| `"missing GitHub sources for bytecode compilation"` | Add the missing dependency to `dependencies` in the config with correct `url`, `commit`, and `relative_root` |
+| Source diffs in OpenZeppelin or other dependency imports | Check the dependency `commit` hash matches what was used at deploy time |
+| Bytecode mismatch after constructor | Add `constructor_calldata` (raw hex) or `constructor_args` (ABI-typed values) for the contract under `bytecode_comparison` |
+| `"Failed to infer source path for library"` | Add library addresses to `bytecode_comparison.libraries` keyed by `"path/to/File.sol": {"LibName": "0xAddr"}` |
 | All files show diffs | Wrong `commit` or `relative_root` in `github_repo` |
-| Single contract fails | May need per-contract `constructor_calldata` entry |
+| Single contract fails | May need a per-contract `constructor_calldata` or `constructor_args` entry |
+| `"Bytecodes have differences not on the immutable reference position"` | Real bytecode mismatch -- check compiler version, optimizer settings, EVM version, and library addresses |
+| `"Exiting with non-zero code due to unallowed diffs"` | Either fix the diffs or use `--allow-source-diff 0xAddr` / `--allow-bytecode-diff 0xAddr` for known acceptable diffs |
 
 ### 4. Suggest a re-run command
 After fixing, suggest:
@@ -58,5 +76,11 @@ After fixing, suggest:
 uv run diffyscan <config-path> --yes --cache-explorer --cache-github
 ```
 
-Use `--cache-explorer` and `--cache-github` to avoid re-fetching unchanged data.
-Use `--allow-source-diff 0xAddr` or `--allow-bytecode-diff 0xAddr` for known acceptable diffs.
+- `--yes` (`-Y`) skips the interactive prompt before each contract
+- `--cache-explorer` (`-E`) reuses cached explorer responses from `.diffyscan_cache/`
+- `--cache-github` (`-G`) reuses cached GitHub file fetches
+- `--support-brownie` enables recursive retrieval for brownie-verified contracts with flattened import paths
+- `--skip-binary-comparison` (`-S`) skips bytecode comparison entirely (useful when debugging source diffs only)
+- `--allow-source-diff 0xAddr` accepts source diffs for a specific address (can be repeated)
+- `--allow-bytecode-diff 0xAddr` accepts bytecode diffs for a specific address (can be repeated)
+- `--log-level warn` or `--quiet` (`-Q`) reduces output noise

--- a/.claude/skills/new-config/SKILL.md
+++ b/.claude/skills/new-config/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: new-config
+description: Create a new diffyscan verification config file for a deployed smart contract. Use when the user wants to verify a new contract or deployment.
+disable-model-invocation: true
+argument-hint: [chain] [contract-address] [github-repo-url]
+---
+
+Create a new diffyscan config file for verifying a deployed smart contract. The user may provide some or all of these details — ask for anything missing.
+
+## Required information
+
+1. **Chain**: Which blockchain (ethereum, optimism, base, zksync, linea, scroll, mantle, bsc, etc.)
+2. **Network**: mainnet or testnet (hoodi/holesky/sepolia for Ethereum)
+3. **Contract address(es)**: One or more `0x`-prefixed addresses and their contract names
+4. **GitHub repo**: URL, commit hash, and relative root within the repo
+5. **Explorer**: hostname and token env var name
+
+## Config schema
+
+Use JSON format by default. YAML if user requests it.
+
+```json
+{
+  "contracts": {
+    "0xAddress": "ContractName"
+  },
+  "explorer_hostname": "api.etherscan.io",
+  "explorer_token_env_var": "ETHERSCAN_EXPLORER_TOKEN",
+  "github_repo": {
+    "url": "https://github.com/org/repo",
+    "commit": "<full-commit-sha>",
+    "relative_root": ""
+  }
+}
+```
+
+## Optional fields (add only when needed)
+
+- `explorer_chain_id` — required for Blockscout explorers and chains where chain ID differs from default
+- `dependencies` — map of import path prefix to `{url, commit, relative_root}`. Common: `@openzeppelin/contracts`, `@openzeppelin/contracts-upgradeable`
+- `bytecode_comparison` — object with:
+  - `constructor_calldata` — raw hex calldata per address: `{"0xAddr": "0xabcd..."}`
+  - `constructor_args` — typed args per address: `{"0xAddr": ["0xarg1", true, 42]}`
+  - `libraries` — per source path: `{"contracts/lib/Foo.sol": {"Foo": "0xLibAddr"}}`
+- `fail_on_bytecode_comparison_error` — set to `true` for strict mode
+- `source_comparison` — set to `false` to skip source diffs (bytecode-only check)
+
+## Explorer hostnames by chain
+
+| Chain      | Hostname                        | Token env var                  |
+|------------|---------------------------------|--------------------------------|
+| Ethereum   | api.etherscan.io                | ETHERSCAN_EXPLORER_TOKEN       |
+| Optimism   | api-optimistic.etherscan.io     | OPTISCAN_EXPLORER_TOKEN        |
+| Base       | api.basescan.org                | BASESCAN_EXPLORER_TOKEN        |
+| BSC        | api.bscscan.com                 | BSCSCAN_TOKEN                  |
+| Linea      | api.lineascan.build             | LINEASCAN_EXPLORER_TOKEN       |
+| Scroll     | api.scrollscan.com              | SCROLLSCAN_EXPLORER_TOKEN      |
+| zkSync     | block-explorer-api.mainnet.zksync.io | (no token needed)         |
+| Mantle     | api.mantlescan.xyz              | MANTLESCAN_EXPLORER_TOKEN      |
+
+For Blockscout-based explorers, set `explorer_chain_id` explicitly.
+
+## File placement
+
+Save configs to `config_samples/<chain>/<network>/` following existing naming conventions. Look at existing configs in that directory for patterns.
+
+## YAML gotchas
+
+If generating YAML: addresses and hex strings MUST be quoted (`"0xabc..."`) — unquoted hex gets parsed as integers by YAML.
+
+## Workflow
+
+1. Gather required info from user (ask for missing pieces)
+2. Look at existing configs in the same chain directory for reference patterns
+3. Create the config file
+4. Suggest running: `uv run diffyscan <config-path> --yes --cache-explorer --cache-github`

--- a/.claude/skills/new-config/SKILL.md
+++ b/.claude/skills/new-config/SKILL.md
@@ -82,7 +82,7 @@ These are Etherscan-compatible and fall through to the default `_get_contract_fr
 | `api-optimistic.etherscan.io` | `OPTISCAN_EXPLORER_TOKEN` | Optimism mainnet |
 | `api.basescan.org` | `ETHERSCAN_EXPLORER_TOKEN` | Base mainnet |
 | `api.lineascan.build` | `LINEA_EXPLORER_TOKEN` | Linea mainnet (special: token is ignored by dispatcher) |
-| `api.scrollscan.com` | (no dedicated token) | Scroll mainnet |
+| `api.scrollscan.com` | `ETHERSCAN_EXPLORER_TOKEN` (fallback) | Scroll mainnet |
 | `api.bscscan.com` | `BSCSCAN_TOKEN` | BSC mainnet |
 | `api-holesky.etherscan.io` | `ETHERSCAN_EXPLORER_TOKEN` | Holesky testnet |
 | `api-hoodi.etherscan.io` | `ETHERSCAN_EXPLORER_TOKEN` | Hoodi testnet |

--- a/.claude/skills/new-config/SKILL.md
+++ b/.claude/skills/new-config/SKILL.md
@@ -112,6 +112,13 @@ Some configs (soneium, unichain) use `explorer_hostname_env_var` instead of `exp
 
 Save configs to `config_samples/<chain>/<network>/` following existing naming conventions. Look at existing configs in that directory for patterns. Some older configs live directly under `config_samples/` (e.g. `lido_dao_holesky_config.json`) or under `config_samples/<chain>/` without a network subdirectory.
 
+## Best practices
+
+- **Use exact commit SHAs** — always use full 40-character commit hashes, never branch names or tags (they can change)
+- **Enable bytecode comparison** — provide `constructor_calldata` or `constructor_args` for contracts with constructors so bytecode verification runs
+- **Include `audit_url`** — link to the relevant audit report when available for cross-reference
+- **Keep configs strict** — prefer explicit over implicit; include all fields even if optional, so verification is as thorough as possible
+
 ## Workflow
 
 1. Gather required info from user (ask for missing pieces)

--- a/.claude/skills/new-config/SKILL.md
+++ b/.claude/skills/new-config/SKILL.md
@@ -98,9 +98,11 @@ These are detected by hostname pattern and use different API backends:
 |---|---|---|---|
 | zkSync | starts with `zksync` | `zksync2-mainnet-explorer.zksync.io` | (none needed) |
 | Mantle | ends with `mantle.xyz` | `explorer.mantle.xyz`, `explorer.testnet.mantle.xyz` | (none needed) |
-| Blockscout | ends with `blockscout.com`, `mode.network`, `swellnetwork.io`, `lisk.com`, `inkonchain.com`, `routescan.io`, `monadvision.com` | `blockscout.lisk.com`, `explorer.mode.network`, `explorer.swellnetwork.io`, `megaeth.blockscout.com`, `explorer.inkonchain.com`, `api.routescan.io/v2/network/mainnet/evm/9745/etherscan` | Varies (some use API keys like `INK_API_KEY`, `MEGAETH_API_KEY`, `PLASMA_API_KEY`; some need none) |
+| Blockscout | ends with `blockscout.com`, `mode.network`, `swellnetwork.io`, `lisk.com`, `inkonchain.com`, `routescan.io`, `monadvision.com` | `blockscout.lisk.com`, `explorer.mode.network`, `explorer.swellnetwork.io`, `megaeth.blockscout.com`, `explorer.inkonchain.com` | Varies (some use API keys like `INK_API_KEY`, `MEGAETH_API_KEY`; some need none) |
 
 Blockscout explorers use the `/api/v2/smart-contracts/{address}` endpoint. Some Blockscout-based explorers (ink, megaeth) also set `explorer_chain_id`.
+
+**Note:** `api.routescan.io/v2/network/mainnet/evm/9745/etherscan` (used for Plasma) does NOT match the Blockscout dispatcher — the hostname ends with `etherscan`, not `routescan.io`. It falls through to the default Etherscan fetcher and uses `PLASMA_API_KEY`.
 
 ### `explorer_hostname_env_var` (CI convention only)
 

--- a/.claude/skills/new-config/SKILL.md
+++ b/.claude/skills/new-config/SKILL.md
@@ -9,7 +9,7 @@ Create a new diffyscan config file for verifying a deployed smart contract. The 
 
 ## Required information
 
-1. **Chain**: Which blockchain (ethereum, optimism, base, zksync, linea, scroll, mantle, bsc, etc.)
+1. **Chain**: Which blockchain (ethereum, optimism, base, zksync, linea, scroll, mantle, bsc, lisk, soneium, unichain, ink, swell, megaeth, plasma, mode, etc.)
 2. **Network**: mainnet or testnet (hoodi/holesky/sepolia for Ethereum)
 3. **Contract address(es)**: One or more `0x`-prefixed addresses and their contract names
 4. **GitHub repo**: URL, commit hash, and relative root within the repo
@@ -17,56 +17,98 @@ Create a new diffyscan config file for verifying a deployed smart contract. The 
 
 ## Config schema
 
-Use JSON format by default. YAML if user requests it.
+Use YAML format by default (supports comments for annotating addresses). JSON if user requests it.
 
-```json
-{
-  "contracts": {
-    "0xAddress": "ContractName"
-  },
-  "explorer_hostname": "api.etherscan.io",
-  "explorer_token_env_var": "ETHERSCAN_EXPLORER_TOKEN",
-  "github_repo": {
-    "url": "https://github.com/org/repo",
-    "commit": "<full-commit-sha>",
-    "relative_root": ""
-  }
-}
+The `Config` TypedDict is defined in `diffyscan/utils/custom_types.py`. Template for new configs:
+
+```yaml
+contracts:
+  "0xAddress": ContractName
+
+network: mainnet  # required in TypedDict but unused at runtime; include for forward-compatibility
+
+explorer_hostname: api.etherscan.io
+explorer_token_env_var: ETHERSCAN_EXPLORER_TOKEN
+explorer_chain_id: 1  # activates Etherscan v2 API
+
+github_repo:
+  url: https://github.com/org/repo
+  commit: "<full-40-char-sha>"
+  relative_root: ""
+
+dependencies: {}
 ```
+
+Note: `explorer_token_env_var`, `explorer_chain_id`, and `dependencies` are `NotRequired` in the TypedDict but should always be included in new configs. `network` is required in the TypedDict.
+
+YAML gotcha: addresses and hex strings MUST be quoted (`"0xabc..."`) — unquoted hex gets parsed as integers. The `load_config` function validates this and raises `ValueError` if coercion is detected.
 
 ## Optional fields (add only when needed)
 
-- `explorer_chain_id` — required for Blockscout explorers and chains where chain ID differs from default
-- `dependencies` — map of import path prefix to `{url, commit, relative_root}`. Common: `@openzeppelin/contracts`, `@openzeppelin/contracts-upgradeable`
+- `dependencies` — map of import path prefix to `{url, commit, relative_root}`. Common: `@openzeppelin/contracts`, `@openzeppelin/contracts-upgradeable`, `lib/openzeppelin-contracts/contracts`
 - `bytecode_comparison` — object with:
   - `constructor_calldata` — raw hex calldata per address: `{"0xAddr": "0xabcd..."}`
   - `constructor_args` — typed args per address: `{"0xAddr": ["0xarg1", true, 42]}`
   - `libraries` — per source path: `{"contracts/lib/Foo.sol": {"Foo": "0xLibAddr"}}`
+  - `hardhat_config_name` — (deprecated) name of a hardhat config file
 - `fail_on_bytecode_comparison_error` — set to `true` for strict mode
 - `source_comparison` — set to `false` to skip source diffs (bytecode-only check)
+- `explorer_hostname_env_var` — config convention for external CI/tooling to pass the explorer hostname via env var (used for soneium, unichain). Note: diffyscan itself does NOT resolve this at runtime — `get_explorer_hostname()` only reads `explorer_hostname`. External scripts must set `explorer_hostname` before invoking diffyscan.
+- `audit_url` — optional link to an audit report for documentation purposes
+- `metadata` — optional object for deployment metadata (e.g. `chain_name`, `deployment_date`, `timelock_address`, `timelock_requirements`)
 
-## Explorer hostnames by chain
+## Explorer configuration
 
-| Chain      | Hostname                        | Token env var                  |
-|------------|---------------------------------|--------------------------------|
-| Ethereum   | api.etherscan.io                | ETHERSCAN_EXPLORER_TOKEN       |
-| Optimism   | api-optimistic.etherscan.io     | OPTISCAN_EXPLORER_TOKEN        |
-| Base       | api.basescan.org                | BASESCAN_EXPLORER_TOKEN        |
-| BSC        | api.bscscan.com                 | BSCSCAN_TOKEN                  |
-| Linea      | api.lineascan.build             | LINEASCAN_EXPLORER_TOKEN       |
-| Scroll     | api.scrollscan.com              | SCROLLSCAN_EXPLORER_TOKEN      |
-| zkSync     | block-explorer-api.mainnet.zksync.io | (no token needed)         |
-| Mantle     | api.mantlescan.xyz              | MANTLESCAN_EXPLORER_TOKEN      |
+The code dispatches to different explorer backends based on the hostname pattern (see `_get_explorer_fetcher()` in `diffyscan/utils/explorer.py`):
 
-For Blockscout-based explorers, set `explorer_chain_id` explicitly.
+### Etherscan v2 API (preferred for Etherscan-supported chains)
+
+Use `api.etherscan.io` as the hostname with `explorer_chain_id` to activate the v2 API (`/v2/api?chainid=`). This works for any Etherscan-supported chain with a single API token.
+
+```json
+"explorer_hostname": "api.etherscan.io",
+"explorer_token_env_var": "ETHERSCAN_EXPLORER_TOKEN",
+"explorer_chain_id": 1
+```
+
+Common chain IDs: Ethereum=1, Optimism=10, Base=8453, BSC=56, Linea=59144, Scroll=534352, Sepolia=11155111, Hoodi=560048, Holesky=17000, Ink=57073, MegaETH=4326.
+
+### Legacy per-chain Etherscan hostnames (still work, used in older configs)
+
+These are Etherscan-compatible and fall through to the default `_get_contract_from_etherscan` backend:
+
+| Hostname | Token env var | Notes |
+|---|---|---|
+| `api-optimistic.etherscan.io` | `OPTISCAN_EXPLORER_TOKEN` | Optimism mainnet |
+| `api.basescan.org` | `ETHERSCAN_EXPLORER_TOKEN` | Base mainnet |
+| `api.lineascan.build` | `LINEA_EXPLORER_TOKEN` | Linea mainnet (special: token is ignored by dispatcher) |
+| `api.scrollscan.com` | (no dedicated token) | Scroll mainnet |
+| `api.bscscan.com` | `BSCSCAN_TOKEN` | BSC mainnet |
+| `api-holesky.etherscan.io` | `ETHERSCAN_EXPLORER_TOKEN` | Holesky testnet |
+| `api-hoodi.etherscan.io` | `ETHERSCAN_EXPLORER_TOKEN` | Hoodi testnet |
+| `api-sepolia.etherscan.io` | `ETHERSCAN_EXPLORER_TOKEN` | Sepolia testnet |
+
+**For new configs, prefer the v2 API approach** (`api.etherscan.io` + `explorer_chain_id`) over legacy per-chain hostnames.
+
+### Non-Etherscan explorers (require their own hostname)
+
+These are detected by hostname pattern and use different API backends:
+
+| Type | Hostname pattern | Example hostnames | Token env var |
+|---|---|---|---|
+| zkSync | starts with `zksync` | `zksync2-mainnet-explorer.zksync.io` | (none needed) |
+| Mantle | ends with `mantle.xyz` | `explorer.mantle.xyz`, `explorer.testnet.mantle.xyz` | (none needed) |
+| Blockscout | ends with `blockscout.com`, `mode.network`, `swellnetwork.io`, `lisk.com`, `inkonchain.com`, `routescan.io`, `monadvision.com` | `blockscout.lisk.com`, `explorer.mode.network`, `explorer.swellnetwork.io`, `megaeth.blockscout.com`, `explorer.inkonchain.com`, `api.routescan.io/v2/network/mainnet/evm/9745/etherscan` | Varies (some use API keys like `INK_API_KEY`, `MEGAETH_API_KEY`, `PLASMA_API_KEY`; some need none) |
+
+Blockscout explorers use the `/api/v2/smart-contracts/{address}` endpoint. Some Blockscout-based explorers (ink, megaeth) also set `explorer_chain_id`.
+
+### `explorer_hostname_env_var` (CI convention only)
+
+Some configs (soneium, unichain) use `explorer_hostname_env_var` instead of `explorer_hostname`. This is a convention for external CI/tooling — diffyscan's `get_explorer_hostname()` only reads `explorer_hostname` directly. External scripts must resolve the env var and set `explorer_hostname` before invoking diffyscan. For new configs, prefer hardcoding `explorer_hostname` directly unless there's a specific CI reason not to.
 
 ## File placement
 
-Save configs to `config_samples/<chain>/<network>/` following existing naming conventions. Look at existing configs in that directory for patterns.
-
-## YAML gotchas
-
-If generating YAML: addresses and hex strings MUST be quoted (`"0xabc..."`) — unquoted hex gets parsed as integers by YAML.
+Save configs to `config_samples/<chain>/<network>/` following existing naming conventions. Look at existing configs in that directory for patterns. Some older configs live directly under `config_samples/` (e.g. `lido_dao_holesky_config.json`) or under `config_samples/<chain>/` without a network subdirectory.
 
 ## Workflow
 

--- a/.claude/skills/validate-config/SKILL.md
+++ b/.claude/skills/validate-config/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: validate-config
+description: Validate a diffyscan config file for correctness before running verification. Checks schema, addresses, required fields, and common mistakes.
+argument-hint: [config-path]
+---
+
+Validate the diffyscan config file at `$ARGUMENTS` (or ask for the path if not provided).
+
+## Checks to perform
+
+### Required fields
+- `contracts` — must be a non-empty dict of `"0x..." : "ContractName"` pairs
+- `explorer_hostname` — must be a string
+- `github_repo` — must have `url`, `commit`, `relative_root`
+  - `commit` should be a full 40-char SHA (warn if short)
+  - `url` should be a valid GitHub URL
+
+### Address validation
+- All contract addresses must start with `0x` and be 42 characters (20 bytes)
+- Check for mixed case (EIP-55 checksummed is fine, but flag all-lowercase or obviously wrong)
+- In YAML files: verify hex strings are quoted (unquoted `0x...` becomes an integer)
+
+### Explorer configuration
+- `explorer_token_env_var` should be present (warn if missing — falls back to ETHERSCAN_EXPLORER_TOKEN)
+- `explorer_hostname` should match a known explorer pattern
+
+### Dependencies
+- Each dependency must have `url`, `commit`, `relative_root`
+- Dependency keys should match import paths used in the Solidity sources
+
+### Bytecode comparison
+- `constructor_calldata` values should be hex strings starting with `0x`
+- `constructor_args` values should be arrays
+- `libraries` should be `{"source/path.sol": {"LibName": "0xAddr"}}`
+- Library addresses must be valid 0x-prefixed 42-char strings
+
+### Cross-references
+- Addresses in `bytecode_comparison.constructor_calldata`, `constructor_args` must exist in `contracts`
+- Warn about contracts in `contracts` that have no bytecode_comparison entry (they'll use explorer defaults — this is usually fine)
+
+## Output
+
+Report issues as errors (must fix) or warnings (should review). If the config looks good, confirm it.
+
+Read the config file using the Read tool and the TypedDict definitions in `diffyscan/utils/custom_types.py` for reference.

--- a/.claude/skills/validate-config/SKILL.md
+++ b/.claude/skills/validate-config/SKILL.md
@@ -1,45 +1,119 @@
 ---
 name: validate-config
-description: Validate a diffyscan config file for correctness before running verification. Checks schema, addresses, required fields, and common mistakes.
+description: Validate a diffyscan config file for correctness before running verification. Checks schema, required fields, type correctness, and common mistakes.
 argument-hint: [config-path]
 ---
 
 Validate the diffyscan config file at `$ARGUMENTS` (or ask for the path if not provided).
 
+Read the config file using the Read tool. Use the TypedDict definitions in `diffyscan/utils/custom_types.py` as the schema reference.
+
+## Schema reference
+
+The `Config` TypedDict (`diffyscan/utils/custom_types.py`) defines:
+
+**Required fields:**
+- `contracts` — `dict[str, str]` mapping address to contract name
+- `network` — `str` (declared required in TypedDict but currently unused at runtime; include it for forward-compatibility)
+- `explorer_hostname` — `str`
+- `github_repo` — `GithubRepo` with required keys: `url`, `commit`, `relative_root`
+
+**Optional fields (NotRequired):**
+- `dependencies` — `dict[str, GithubRepo]`
+- `explorer_token_env_var` — `str`
+- `explorer_chain_id` — `int`
+- `bytecode_comparison` — `BinaryConfig`
+- `fail_on_bytecode_comparison_error` — `bool`
+- `source_comparison` — `bool`
+
+**Additional fields found in real configs but not in the TypedDict:**
+- `explorer_hostname_env_var` — `str` (CI convention only — diffyscan does NOT resolve this at runtime; external tooling must set `explorer_hostname` before invoking)
+- `audit_url` — `str`
+- `metadata` — `dict` (free-form project metadata)
+
+The `BinaryConfig` TypedDict has all-optional fields:
+- `hardhat_config_name` — `str` (deprecated, ignored at runtime)
+- `constructor_calldata` — `dict[str, str]` mapping address to raw hex calldata
+- `constructor_args` — `dict[str, list]` mapping address to a list of ABI-encodable arguments
+- `libraries` — `dict[str, dict[str, str]]` mapping source path to `{LibraryName: "0xAddress"}`
+
 ## Checks to perform
 
-### Required fields
-- `contracts` — must be a non-empty dict of `"0x..." : "ContractName"` pairs
-- `explorer_hostname` — must be a string
-- `github_repo` — must have `url`, `commit`, `relative_root`
-  - `commit` should be a full 40-char SHA (warn if short)
-  - `url` should be a valid GitHub URL
+### 1. Required fields
 
-### Address validation
-- All contract addresses must start with `0x` and be 42 characters (20 bytes)
-- Check for mixed case (EIP-55 checksummed is fine, but flag all-lowercase or obviously wrong)
-- In YAML files: verify hex strings are quoted (unquoted `0x...` becomes an integer)
+- `contracts` must be present and be a non-empty dict
+- `explorer_hostname` must be a string (or alternatively `explorer_hostname_env_var` must be present; real configs use one or both -- see `tests/test_configs.py` line 32)
+- `github_repo` must be present and contain all three keys: `url`, `commit`, `relative_root`
+- `network` is declared required in the TypedDict. Warn if missing, noting it is not used at runtime today but may be in the future
 
-### Explorer configuration
-- `explorer_token_env_var` should be present (warn if missing — falls back to ETHERSCAN_EXPLORER_TOKEN)
-- `explorer_hostname` should match a known explorer pattern
+### 2. YAML hex coercion (what the codebase actually validates)
 
-### Dependencies
-- Each dependency must have `url`, `commit`, `relative_root`
-- Dependency keys should match import paths used in the Solidity sources
+The function `_validate_yaml_hex_keys` in `diffyscan/utils/common.py` checks YAML configs for hex values that PyYAML silently coerced from strings to integers. It raises `ValueError` if any are found. Specifically it checks:
 
-### Bytecode comparison
-- `constructor_calldata` values should be hex strings starting with `0x`
-- `constructor_args` values should be arrays
-- `libraries` should be `{"source/path.sol": {"LibName": "0xAddr"}}`
-- Library addresses must be valid 0x-prefixed 42-char strings
+- **`contracts` keys** (address) -- raises if parsed as `int`
+- **`contracts` values** (contract name) -- raises if parsed as `int`
+- **`bytecode_comparison.constructor_args` keys** -- raises if parsed as `int`
+- **`bytecode_comparison.constructor_calldata` keys** -- raises if parsed as `int`
+- **`bytecode_comparison.libraries` values** (the library address strings) -- raises if parsed as `int`
 
-### Cross-references
-- Addresses in `bytecode_comparison.constructor_calldata`, `constructor_args` must exist in `contracts`
-- Warn about contracts in `contracts` that have no bytecode_comparison entry (they'll use explorer defaults — this is usually fine)
+This validation only runs for YAML files, not JSON. It only detects `int` coercion; it does NOT validate address format (0x prefix, 42 chars, valid hex, checksum).
+
+### 3. Address format (best-practice recommendation only)
+
+The codebase does NOT validate address format at config load time. There is no runtime check for 0x prefix, 42-character length, or hex validity on addresses in the config. Addresses are passed directly to the explorer API and RPC node.
+
+However, the test suite (`tests/test_configs.py:test_contract_addresses_format`) asserts all `contracts` keys start with `0x` and are 42 characters. Recommend the same for any address in the config:
+- Contract addresses in `contracts` keys
+- Addresses in `bytecode_comparison.constructor_calldata` keys
+- Addresses in `bytecode_comparison.constructor_args` keys
+- Library addresses in `bytecode_comparison.libraries` values
+
+### 4. Explorer configuration
+
+- If `explorer_token_env_var` is missing, the runtime warns and falls back to `ETHERSCAN_EXPLORER_TOKEN` (see `_load_explorer_token` in `diffyscan/diffyscan.py`). Warn if absent.
+- `explorer_chain_id` is optional; the runtime does not warn if missing (retrieved with `warn_if_missing=False`)
+- `explorer_hostname` is retrieved with `warn_if_missing=True`; if absent the runtime logs a warning
+
+### 5. GitHub repo fields
+
+- `github_repo.url` should look like a GitHub URL
+- `github_repo.commit` should ideally be a full 40-character SHA hex string (warn if short or non-hex)
+- `github_repo.relative_root` can be an empty string (commonly is for root-level repos)
+
+### 6. Dependencies
+
+- Each dependency value must have `url`, `commit`, `relative_root` (same `GithubRepo` shape)
+- Dependency keys should match import path prefixes used in Solidity sources (e.g. `@openzeppelin/contracts`, `lib/openzeppelin-contracts-upgradeable/contracts`)
+- The runtime resolves dependencies by checking if a source file path starts with `"{dep_name}/"` (see `resolve_dep` in `diffyscan/utils/github.py`)
+
+### 7. Bytecode comparison
+
+- `constructor_calldata` values should be hex strings (the runtime strips `0x` prefix via `normalize_calldata` and validates hex content)
+- `constructor_args` values must be lists (arrays of ABI-encodable values)
+- A contract address must NOT appear in both `constructor_calldata` and `constructor_args` -- the runtime raises `CalldataError` if it does (see `get_calldata` in `diffyscan/utils/calldata.py`)
+- `libraries` maps Solidity source file paths to `{LibraryName: "0xAddress"}` dicts
+- `hardhat_config_name` is deprecated and ignored at runtime (a warning is logged)
+
+### 8. Cross-reference checks
+
+What the runtime actually does:
+- Addresses in `bytecode_comparison.constructor_calldata` and `constructor_args` are looked up by contract address at runtime -- if a contract has a constructor but its address is not in either dict and the explorer has no constructor arguments, the runtime raises `CalldataError`
+- Contracts listed in `contracts` that have no corresponding entry in `bytecode_comparison` will still work -- they fall back to explorer-provided constructor arguments
+- There is no compile-time cross-reference validation in the codebase; all checks happen at runtime
+
+Recommended cross-reference warnings:
+- Warn if an address appears in `constructor_calldata` or `constructor_args` but not in `contracts` (it would be unused)
+- Warn if a contract is in both `constructor_calldata` and `constructor_args` (runtime error)
+
+### 9. Optional flags
+
+- `fail_on_bytecode_comparison_error` defaults to `true` if absent
+- `source_comparison` defaults to `true` if absent; set to `false` to skip source diffs
 
 ## Output
 
-Report issues as errors (must fix) or warnings (should review). If the config looks good, confirm it.
+Report issues in two categories:
+- **Errors** (must fix): missing required fields, type mismatches, YAML hex coercion, duplicate entries in both `constructor_calldata` and `constructor_args`
+- **Warnings** (should review): missing `explorer_token_env_var`, short commit SHA, addresses not matching 0x/42-char format, missing `network`, deprecated `hardhat_config_name`, unused bytecode_comparison entries
 
-Read the config file using the Read tool and the TypedDict definitions in `diffyscan/utils/custom_types.py` for reference.
+If the config looks good, confirm it passes validation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ bytecode_comparison: { constructor_calldata, constructor_args, libraries }
 
 ### Environment variables
 
-Requires `.env` file (see `.env.example`): `GITHUB_API_TOKEN`, `ETHERSCAN_EXPLORER_TOKEN`, `REMOTE_RPC_URL` (for bytecode comparison).
+Supports loading from `.env` (see `.env.example`), or set directly: `GITHUB_API_TOKEN`, `ETHERSCAN_EXPLORER_TOKEN`, `REMOTE_RPC_URL` (for bytecode comparison).
 
 ## Code style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is Diffyscan
+
+Diffyscan verifies deployed EVM smart contracts match their GitHub source by:
+1. Fetching verified source from blockchain explorers (Etherscan, Blockscout, zkSync, Mantle)
+2. Diffing against GitHub repo sources (HTML diff reports saved to `digest/`)
+3. Optionally recompiling from GitHub and comparing bytecode against on-chain bytecode, handling constructor args, libraries, and immutable references
+
+## Commands
+
+```bash
+# Install dependencies
+uv sync --locked --group dev
+
+# Run tests
+uv run pytest -q
+
+# Run a single test
+uv run pytest tests/test_config_loading.py -q
+uv run pytest tests/test_config_loading.py::test_name -q
+
+# Run the CLI
+uv run diffyscan config_samples/lido_dao_sepolia_config.json
+
+# Format code
+uv run black diffyscan/ tests/
+
+# Run pre-commit hooks
+uv run pre-commit run --all-files
+
+# Install git hooks (pre-commit + commit-msg via gitlint)
+uv run pre-commit install --hook-type pre-commit --hook-type commit-msg
+```
+
+## Architecture
+
+Entry point: `diffyscan/diffyscan.py:main` — parses CLI args, loads config (JSON or YAML), then runs source diff and bytecode diff for each contract.
+
+### Core flow
+
+`process_config()` orchestrates per-config:
+- `run_source_diff()` — fetches explorer sources and GitHub sources, generates HTML diffs via `difflib.HtmlDiff`
+- `run_bytecode_diff()` — compiles GitHub sources with solc, simulates deployment via `eth_call`, compares bytecode
+
+### Utility modules (`diffyscan/utils/`)
+
+- **explorer.py** — largest module; fetches/parses contracts from blockchain explorers, handles multi-chain API differences, library detection, EVM version normalization, solc compilation
+- **github.py** — GitHub API integration, file fetching with caching, dependency resolution (e.g. `@openzeppelin/contracts-v4.4`)
+- **binary_verifier.py** — EVM bytecode parsing into instructions, metadata trimming, deep comparison with immutable region exclusion
+- **compiler.py** — solc binary download (platform-aware), SHA256 verification, compilation via standard JSON
+- **encoder.py** — ABI encoding for constructor arguments (address, bool, int/uint, bytes, tuples, arrays)
+- **calldata.py** — resolves constructor calldata from config or explorer metadata
+- **node_handler.py** — RPC calls: `eth_getCode`, `eth_chainId`, `eth_call`
+- **common.py** — config loading (with YAML hex address validation), HTTP helpers, caching with SHA256 validation
+- **custom_types.py** — TypedDict definitions: `Config`, `BinaryConfig`, `ExplorerContract`, `GithubRepo`
+- **custom_exceptions.py** — exception hierarchy; `ExceptionHandler` controls fail-or-log behavior
+
+### Config schema
+
+Configs live in `config_samples/` organized by chain (ethereum, optimism, zksync, etc.):
+```
+contracts:          { "0xaddr": "ContractName" }
+explorer_hostname:  "api.etherscan.io"
+explorer_token_env_var: "ETHERSCAN_EXPLORER_TOKEN"
+github_repo:        { url, commit, relative_root }
+dependencies:       { "dep_name": { url, commit, relative_root } }
+bytecode_comparison: { constructor_calldata, constructor_args, libraries }
+```
+
+### Environment variables
+
+Requires `.env` file (see `.env.example`): `GITHUB_API_TOKEN`, `ETHERSCAN_EXPLORER_TOKEN`, `REMOTE_RPC_URL` (for bytecode comparison).
+
+## Code style
+
+- Formatter: **black** (enforced via pre-commit)
+- Commit messages: validated by **gitlint**
+- Python >=3.11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Entry point: `diffyscan/diffyscan.py:main` — parses CLI args, loads config (JS
 Configs live in `config_samples/` organized by chain (ethereum, optimism, zksync, etc.):
 ```
 contracts:          { "0xaddr": "ContractName" }
+network:            "mainnet"  # required in TypedDict, unused at runtime
 explorer_hostname:  "api.etherscan.io"
 explorer_token_env_var: "ETHERSCAN_EXPLORER_TOKEN"
 github_repo:        { url, commit, relative_root }


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — project guidance file for Claude Code: common commands, architecture overview, config schema, and code style conventions
- **4 custom skills** in `.claude/skills/`:
  - `/new-config` — generate a verification config for a new contract/deployment, with full schema reference and per-chain explorer hostnames
  - `/validate-config` — validate a config file before running (addresses, required fields, YAML quoting, cross-references)
  - `/debug-diff` — diagnose failed verifications: walks through digest output, identifies root causes, suggests fixes
  - `/add-explorer` — step-by-step guide for adding a new blockchain explorer API, covering the dispatch architecture in `explorer.py`

## Test plan

- [x] Verify `/new-config` generates a valid config when invoked in Claude Code
- [x] Verify `/validate-config` catches common mistakes (missing fields, unquoted YAML hex, bad addresses)
- [x] Verify `/debug-diff` provides useful guidance after a failed `diffyscan` run
- [x] Verify `/add-explorer` instructions are accurate against current `explorer.py` structure