### PR TITLE
fix: raise CompileError when solc returns no contracts to avoid batch crash

### DIFF
--- a/diffyscan/utils/compiler.py
+++ b/diffyscan/utils/compiler.py
@@ -107,7 +107,25 @@ def compile_contracts(compiler_path: str, input_settings: str) -> dict:
         raise CompileError(f"Compiler process timed out: {e}")
     except Exception as e:
         raise CompileError(f"An unexpected error occurred: {e}")
-    return json.loads(process.stdout)
+
+    try:
+        output = json.loads(process.stdout)
+    except json.JSONDecodeError as e:
+        raise CompileError(
+            f"solc produced non-JSON output: {e}; stdout head: {process.stdout[:500]!r}"
+        )
+
+    if "contracts" not in output:
+        errors = output.get("errors") or []
+        fatal = [e for e in errors if e.get("severity") == "error"] or errors
+        msgs = "\n".join(
+            e.get("formattedMessage") or e.get("message") or str(e) for e in fatal
+        )
+        raise CompileError(
+            f"solc returned no contracts ({len(fatal)} error(s)):\n{msgs}"
+        )
+
+    return output
 
 
 def get_target_compiled_contract(

--- a/diffyscan/utils/compiler.py
+++ b/diffyscan/utils/compiler.py
@@ -110,7 +110,7 @@ def compile_contracts(compiler_path: str, input_settings: str) -> dict:
 
     try:
         output = json.loads(process.stdout)
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, UnicodeDecodeError, TypeError) as e:
         raise CompileError(
             f"solc produced non-JSON output: {e}; stdout head: {process.stdout[:500]!r}"
         )

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,0 +1,89 @@
+"""Tests for diffyscan.utils.compiler.compile_contracts error handling."""
+
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from diffyscan.utils.compiler import compile_contracts
+from diffyscan.utils.custom_exceptions import CompileError
+
+
+def _fake_run(stdout: bytes):
+    def runner(*args, **kwargs):
+        return SimpleNamespace(stdout=stdout, stderr=b"", returncode=0)
+
+    return runner
+
+
+def test_compile_contracts_raises_when_output_has_no_contracts(monkeypatch):
+    """solc returning only errors must surface a CompileError, not KeyError downstream."""
+    errors_only = json.dumps(
+        {
+            "errors": [
+                {
+                    "severity": "error",
+                    "formattedMessage": (
+                        'ParserError: Source "@openzeppelin/contracts/utils/'
+                        'cryptography/MessageHashUtils.sol" not found.'
+                    ),
+                    "message": "Source not found",
+                }
+            ]
+        }
+    ).encode()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run(errors_only))
+
+    with pytest.raises(CompileError) as excinfo:
+        compile_contracts("/fake/solc", "{}")
+
+    msg = str(excinfo.value)
+    assert "solc returned no contracts" in msg
+    assert "MessageHashUtils.sol" in msg
+
+
+def test_compile_contracts_filters_warnings_when_no_contracts(monkeypatch):
+    """Warnings should be ignored when picking which messages to surface."""
+    payload = json.dumps(
+        {
+            "errors": [
+                {"severity": "warning", "message": "spdx warning"},
+                {
+                    "severity": "error",
+                    "formattedMessage": "DeclarationError: Identifier not found.",
+                },
+            ]
+        }
+    ).encode()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run(payload))
+
+    with pytest.raises(CompileError) as excinfo:
+        compile_contracts("/fake/solc", "{}")
+
+    msg = str(excinfo.value)
+    assert "DeclarationError" in msg
+    assert "spdx warning" not in msg
+    assert "1 error(s)" in msg
+
+
+def test_compile_contracts_raises_on_invalid_json(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _fake_run(b"not json at all"))
+
+    with pytest.raises(CompileError) as excinfo:
+        compile_contracts("/fake/solc", "{}")
+
+    assert "non-JSON output" in str(excinfo.value)
+
+
+def test_compile_contracts_returns_output_on_success(monkeypatch):
+    payload = json.dumps(
+        {"contracts": {"Demo.sol": {"Demo": {"abi": [], "evm": {}}}}}
+    ).encode()
+    monkeypatch.setattr(subprocess, "run", _fake_run(payload))
+
+    result = compile_contracts("/fake/solc", "{}")
+    assert "contracts" in result
+    assert "Demo" in result["contracts"]["Demo.sol"]


### PR DESCRIPTION
## Summary

- `compile_contracts()` returned `json.loads(stdout)` without checking for `"contracts"`. When solc returned an errors-only response (e.g. unresolved import from version drift in a dependency), `compile_contract_from_explorer()` did `compile_contracts(...)["contracts"]` and raised `KeyError`.
- `KeyError` is not a `BaseCustomException`, so it bypassed both the per-contract and outer handlers in `process_config`, killing the whole batch — one bad implementation address took down all remaining contracts in the config.
- Fix: `compile_contracts()` now raises a structured `CompileError` with formatted solc error messages when output has no `"contracts"` key, and also when stdout is non-JSON. The existing `except BaseCustomException` in `process_config` then catches it and continues with the next contract.

## Test plan

- [x] `uv run pytest -q` — 92 passed
- [x] New `tests/test_compiler.py` covers: errors-only output, warning-only filtering, invalid JSON, happy path
- [x] `uv run black --check diffyscan/utils/compiler.py tests/test_compiler.py`