### PR TITLE
docs: fix AI-doc drift vs code

### DIFF
--- a/.claude/skills/debug-diff/SKILL.md
+++ b/.claude/skills/debug-diff/SKILL.md
@@ -41,7 +41,7 @@ ls digest/<timestamp>/diffs/<contract_address>/
 - Missing or wrong constructor arguments -- see `constructor_calldata` or `constructor_args` under the `bytecode_comparison` config key
 - Missing libraries -- check if the contract uses external libraries that need addresses in `bytecode_comparison.libraries`
 - Wrong EVM version -- the explorer may report a different version than expected
-- Immutable variables -- `deep_match_bytecode()` in `diffyscan/utils/binary_verifier.py` compares instruction-by-instruction and tolerates differences that fall within known immutable reference regions. If all diffs are in immutable positions it logs a warning and returns `False` (still reported as a non-match — use `--allow-bytecode-diff 0xAddr` to accept). Differences outside immutable regions raise `BinVerifierError`
+- Immutable variables -- `deep_match_bytecode()` in `diffyscan/utils/binary_verifier.py` compares instruction-by-instruction and tolerates differences that fall within known immutable reference regions. If all diffs are in immutable positions it logs a warning and returns `False` (still reported as a non-match — use `--allow-bytecode-diff 0xAddr` to accept). Differences outside immutable regions raise `BinVerifierError`, which `process_config` catches and records as a non-match (`match=False`) — it does not abort the run
 - Optimizer settings mismatch -- the solcInput from the explorer includes optimizer settings; the GitHub recompilation must match
 - Flat-source contracts -- see **Known limitations** section below
 
@@ -68,7 +68,7 @@ ls digest/<timestamp>/diffs/<contract_address>/
 | `"Failed to infer source path for library '...' from explorer metadata"` | Add library addresses to `bytecode_comparison.libraries` keyed by `"path/to/File.sol": {"LibName": "0xAddr"}` |
 | All files show diffs | Wrong `commit` or `relative_root` in `github_repo` |
 | Single contract fails | May need a per-contract `constructor_calldata` or `constructor_args` entry |
-| `"Bytecodes have differences not on the immutable reference position"` | Real bytecode mismatch -- check compiler version, optimizer settings, EVM version, and library addresses |
+| `"Failed in binary comparison: Bytecodes have differences not on the immutable reference position"` | Real bytecode mismatch -- check compiler version, optimizer settings, EVM version, and library addresses |
 | `"Exiting with non-zero code due to unallowed diffs"` | Either fix the diffs or use `--allow-source-diff 0xAddr` / `--allow-bytecode-diff 0xAddr` for known acceptable diffs |
 | `"Contract name in config does not match with blockchain explorer ... !="` | Contract not verified on explorer — comment it out or verify it on the explorer first |
 | `"Failed to get calldata: Explorer metadata has empty constructor calldata for 0x..."` | Factory-created contract — Etherscan has no constructor args. Add `constructor_calldata` manually (extract via `getsourcecode` API `ConstructorArguments`, `debug_traceTransaction` trace, or cross-chain reuse) |

--- a/.claude/skills/new-config/SKILL.md
+++ b/.claude/skills/new-config/SKILL.md
@@ -51,7 +51,7 @@ YAML gotcha: addresses and hex strings MUST be quoted (`"0xabc..."`) — unquote
   - `constructor_args` — typed args per address: `{"0xAddr": ["0xarg1", true, 42]}`
   - `libraries` — per source path: `{"contracts/lib/Foo.sol": {"Foo": "0xLibAddr"}}`
   - `hardhat_config_name` — (deprecated) name of a hardhat config file
-- `fail_on_bytecode_comparison_error` — defaults to `true` (strict); set to `false` to log bytecode comparison errors instead of failing the run
+- `fail_on_bytecode_comparison_error` — defaults to `true`; when `false`, a per-contract exception (e.g. failing to fetch/verify a contract from the explorer) is logged and the run continues instead of aborting. Despite the name, an actual error inside `run_bytecode_diff` is always caught and recorded as a mismatch (`match=False`) regardless of this flag.
 - `source_comparison` — set to `false` to skip source diffs (bytecode-only check)
 - `rpc_url_env_var` — name of the env var holding the RPC URL for bytecode comparison (defaults to `REMOTE_RPC_URL`; e.g. `MANTLE_RPC_URL`, `PLASMA_RPC_URL`)
 - `deployment_gas_limit` — optional gas limit for the `eth_call` deployment simulation (helps on chains where the default reverts with "intrinsic gas too low")

--- a/.claude/skills/new-config/SKILL.md
+++ b/.claude/skills/new-config/SKILL.md
@@ -51,8 +51,10 @@ YAML gotcha: addresses and hex strings MUST be quoted (`"0xabc..."`) — unquote
   - `constructor_args` — typed args per address: `{"0xAddr": ["0xarg1", true, 42]}`
   - `libraries` — per source path: `{"contracts/lib/Foo.sol": {"Foo": "0xLibAddr"}}`
   - `hardhat_config_name` — (deprecated) name of a hardhat config file
-- `fail_on_bytecode_comparison_error` — set to `true` for strict mode
+- `fail_on_bytecode_comparison_error` — defaults to `true` (strict); set to `false` to log bytecode comparison errors instead of failing the run
 - `source_comparison` — set to `false` to skip source diffs (bytecode-only check)
+- `rpc_url_env_var` — name of the env var holding the RPC URL for bytecode comparison (defaults to `REMOTE_RPC_URL`; e.g. `MANTLE_RPC_URL`, `PLASMA_RPC_URL`)
+- `deployment_gas_limit` — optional gas limit for the `eth_call` deployment simulation (helps on chains where the default reverts with "intrinsic gas too low")
 - `explorer_hostname_env_var` — config convention for external CI/tooling to pass the explorer hostname via env var (used for soneium, unichain). Note: diffyscan itself does NOT resolve this at runtime — `get_explorer_hostname()` only reads `explorer_hostname`. External scripts must set `explorer_hostname` before invoking diffyscan.
 - `audit_url` — optional link to an audit report for documentation purposes
 - `metadata` — optional object for deployment metadata (e.g. `chain_name`, `deployment_date`, `timelock_address`, `timelock_requirements`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Diffyscan verifies deployed EVM smart contracts match their GitHub source by:
 1. Fetching verified source from blockchain explorers (Etherscan, Blockscout, zkSync, Mantle)
-2. Diffing against GitHub repo sources (HTML diff reports saved to `digest/`)
+2. Diffing against GitHub repo sources (HTML diff reports saved under `digest/<timestamp>/diffs/`)
 3. Optionally recompiling from GitHub and comparing bytecode against on-chain bytecode, handling constructor args, libraries, and immutable references
 
 ## Commands


### PR DESCRIPTION
Audited the AI docs (`CLAUDE.md` + `.claude/skills/*`) against the actual code and fixed the factual drift found. Docs were largely accurate; these are the real mismatches.

## Fixes
- **new-config** — `fail_on_bytecode_comparison_error` was described as "set to `true` for strict mode", but `true` is already the default (`diffyscan.py`); reworded to "defaults to `true`; set to `false` to log instead of fail". Also documented two config keys the code reads but the skill omitted: `rpc_url_env_var` and `deployment_gas_limit`.
- **debug-diff** — "differences outside immutable regions raise `BinVerifierError`" implied a fatal abort; clarified that `process_config` catches it and records a non-match (`match=False`). Also quoted the full user-visible log line (`Failed in binary comparison: ...`).
- **CLAUDE.md** — HTML diff path corrected to `digest/<timestamp>/diffs/`.

## Not changed
- `validate-config` and `add-explorer` had no real drift.
- A separate, more serious finding (zkSync explorer fetcher likely broken — missing `solcInput` + `ContractName` casing) is filed as #163 rather than fixed here.