### PR TITLE
build: track devcontainer images via dependabot

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,12 @@
-ARG DEVCONTAINER_BASE_IMAGE=mcr.microsoft.com/devcontainers/python:3.11@sha256:f46978552419eb3cbf3bcf662ba0dca1639b07307f64447a3fcbe46110710b27
-FROM ${DEVCONTAINER_BASE_IMAGE}
-
 # uv binary from Astral's official image, the same vendor that ships the uv wheel on PyPI.
-# Pinned by digest; the tag stays so Dependabot bumps both together.
-# COPY --from copies only the static /uv and /uvx binaries; the OS layers stay out.
+# A literal FROM stage (pinned by digest, tag kept) so Dependabot's docker ecosystem bumps it.
+# COPY --from below copies only the static /uv and /uvx binaries; the OS layers stay out.
 # BuildKit attaches build provenance and an SBOM as attestation manifests; verify with:
-#   gh attestation verify oci://ghcr.io/astral-sh/uv:0.10.9 --owner astral-sh
-COPY --from=ghcr.io/astral-sh/uv:0.10.9@sha256:10902f58a1606787602f303954cea099626a4adb02acbac4c69920fe9d278f82 /uv /uvx /bin/
+#   gh attestation verify oci://ghcr.io/astral-sh/uv:<version> --owner astral-sh
+FROM ghcr.io/astral-sh/uv:0.10.9@sha256:10902f58a1606787602f303954cea099626a4adb02acbac4c69920fe9d278f82 AS uv
+
+FROM mcr.microsoft.com/devcontainers/python:3.11@sha256:f46978552419eb3cbf3bcf662ba0dca1639b07307f64447a3fcbe46110710b27
+
+COPY --from=uv /uv /uvx /bin/
 
 RUN uv --version

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
 ARG DEVCONTAINER_BASE_IMAGE=mcr.microsoft.com/devcontainers/python:3.11@sha256:f46978552419eb3cbf3bcf662ba0dca1639b07307f64447a3fcbe46110710b27
 FROM ${DEVCONTAINER_BASE_IMAGE}
 
-ARG UV_VERSION=0.10.9
+# uv binary from Astral's official image, the same vendor that ships the uv wheel on PyPI.
+# Pinned by digest; the tag stays so Dependabot bumps both together.
+# COPY --from copies only the static /uv and /uvx binaries; the OS layers stay out.
+# BuildKit attaches build provenance and an SBOM as attestation manifests; verify with:
+#   gh attestation verify oci://ghcr.io/astral-sh/uv:0.10.9 --owner astral-sh
+COPY --from=ghcr.io/astral-sh/uv:0.10.9@sha256:10902f58a1606787602f303954cea099626a4adb02acbac4c69920fe9d278f82 /uv /uvx /bin/
 
-RUN python -m pip install \
-    --disable-pip-version-check \
-    --no-cache-dir \
-    --only-binary=:all: \
-    "uv==${UV_VERSION}" \
-    && python -m uv --version
+RUN uv --version

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "context": "..",
-    "options": ["--platform=linux/amd64"],
-    "args": {
-      "DEVCONTAINER_BASE_IMAGE": "mcr.microsoft.com/devcontainers/python:3.11@sha256:f46978552419eb3cbf3bcf662ba0dca1639b07307f64447a3fcbe46110710b27"
-    }
+    "options": ["--platform=linux/amd64"]
   },
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,7 @@
     "context": "..",
     "options": ["--platform=linux/amd64"],
     "args": {
-      "DEVCONTAINER_BASE_IMAGE": "mcr.microsoft.com/devcontainers/python:3.11@sha256:f46978552419eb3cbf3bcf662ba0dca1639b07307f64447a3fcbe46110710b27",
-      "UV_VERSION": "0.10.9"
+      "DEVCONTAINER_BASE_IMAGE": "mcr.microsoft.com/devcontainers/python:3.11@sha256:f46978552419eb3cbf3bcf662ba0dca1639b07307f64447a3fcbe46110710b27"
     }
   },
   "postCreateCommand": "bash .devcontainer/post-create.sh",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,19 @@ updates:
     commit-message:
       prefix: "ci"
 
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      docker:
+        patterns: ["*"]
+    labels: ["dependencies", "docker"]
+    commit-message:
+      prefix: "build"
+
   - package-ecosystem: "uv"
     directory: "/"
     schedule:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -15,7 +15,6 @@ jobs:
       ETHERSCAN_EXPLORER_TOKEN: ${{ secrets.ETHERSCAN_EXPLORER_TOKEN }}
       GITHUB_API_TOKEN: ${{ github.token }}
       REMOTE_RPC_URL: ${{ matrix.network == 'mainnet' && secrets['REMOTE_RPC_URL_MAINNET'] || secrets['REMOTE_RPC_URL_HOODI'] }}
-      UV_VERSION: "0.10.9"
     strategy:
       fail-fast: false
       matrix:
@@ -123,7 +122,6 @@ jobs:
           docker buildx create --use --name diffyscan-builder
           docker buildx inspect --bootstrap
           docker buildx build \
-            --build-arg UV_VERSION="${UV_VERSION}" \
             --cache-from "type=local,src=${DEVCONTAINER_BUILD_CACHE_DIR}" \
             --cache-to "type=local,dest=${DEVCONTAINER_BUILD_CACHE_DIR}-new,mode=max" \
             --file .devcontainer/Dockerfile \


### PR DESCRIPTION
Follow-up to #165.

## What and why

- **Docker block in `dependabot.yml`** (`directory: /.devcontainer`) tracks both devcontainer images. Dependabot's Docker parser reads version references only from literal `FROM` lines, so both the base image (`mcr.microsoft.com/devcontainers/python:3.11`) and the uv image sit on their own `FROM` line. The base image builds and runs in `regression.yml`, inside the trusted verification path.
- **uv comes from Astral's official image as a `FROM … AS uv` stage**; `COPY --from=uv` then lifts the `/uv` and `/uvx` binaries. This replaces `pip install uv==…` and pins the uv version in one place (`Dockerfile`) instead of three (`Dockerfile`, `devcontainer.json`, `regression.yml`).

Both bullets close the open follow-ups from the #165 review: the docker block and the `UV_VERSION` drift.

## uv image safety

- We already trusted Astral for the uv wheel on PyPI. This pulls the same vendor's binary over a different channel.
- The Dockerfile pins the image by digest (`@sha256:10902f…`), like the base image. That beats the old `pip install uv==…` running without `--require-hashes`.
- `COPY --from=uv` copies only the static `/uv` and `/uvx` binaries; the source image's OS layers stay out of the runtime.
- Each platform image carries an attestation manifest (SLSA build provenance plus SBOM). Verify it with `gh attestation verify oci://ghcr.io/astral-sh/uv:0.10.9 --owner astral-sh`.
