### PR TITLE
chore: Refactor bytecode result deduplication and config validation

### DIFF
--- a/diffyscan/diffyscan.py
+++ b/diffyscan/diffyscan.py
@@ -190,7 +190,7 @@ def run_bytecode_diff(
         contract_address_from_config, remote_rpc_url
     )
 
-    if local_compiled_bytecode == remote_deployed_bytecode:
+    def exact_match() -> dict:
         logger.okay("Bytecodes fully match")
         return _bytecode_result(
             contract_address_from_config,
@@ -199,6 +199,9 @@ def run_bytecode_diff(
             match=True,
             has_diff=False,
         )
+
+    if local_compiled_bytecode == remote_deployed_bytecode:
+        return exact_match()
 
     logger.info("Static bytecodes do not match, simulating constructor via eth_call")
 
@@ -216,14 +219,7 @@ def run_bytecode_diff(
     )
 
     if local_deployed_bytecode == remote_deployed_bytecode:
-        logger.okay("Bytecodes fully match")
-        return _bytecode_result(
-            contract_address_from_config,
-            contract_name_from_config,
-            status="exact",
-            match=True,
-            has_diff=False,
-        )
+        return exact_match()
 
     base_analysis = analyze_bytecode_diff(
         local_deployed_bytecode,

--- a/diffyscan/diffyscan.py
+++ b/diffyscan/diffyscan.py
@@ -107,6 +107,29 @@ def _build_github_solc_input(
     return github_solc_input, missing
 
 
+def _bytecode_result(
+    contract_address: str,
+    contract_name: str,
+    *,
+    status: str,
+    match: bool,
+    has_diff: bool = True,
+    matched_rule: dict | None = None,
+    matched_facets: list | None = None,
+    suggestion_entry: dict | None = None,
+) -> dict:
+    return {
+        "contract_address": contract_address,
+        "contract_name": contract_name,
+        "status": status,
+        "match": match,
+        "has_diff": has_diff,
+        "matched_rule": matched_rule,
+        "matched_facets": matched_facets or [],
+        "suggestion_entry": suggestion_entry,
+    }
+
+
 def run_bytecode_diff(
     contract_address_from_config,
     contract_name_from_config,
@@ -169,16 +192,13 @@ def run_bytecode_diff(
 
     if local_compiled_bytecode == remote_deployed_bytecode:
         logger.okay("Bytecodes fully match")
-        return {
-            "contract_address": contract_address_from_config,
-            "contract_name": contract_name_from_config,
-            "status": "exact",
-            "match": True,
-            "has_diff": False,
-            "matched_rule": None,
-            "matched_facets": [],
-            "suggestion_entry": None,
-        }
+        return _bytecode_result(
+            contract_address_from_config,
+            contract_name_from_config,
+            status="exact",
+            match=True,
+            has_diff=False,
+        )
 
     logger.info("Static bytecodes do not match, simulating constructor via eth_call")
 
@@ -197,16 +217,13 @@ def run_bytecode_diff(
 
     if local_deployed_bytecode == remote_deployed_bytecode:
         logger.okay("Bytecodes fully match")
-        return {
-            "contract_address": contract_address_from_config,
-            "contract_name": contract_name_from_config,
-            "status": "exact",
-            "match": True,
-            "has_diff": False,
-            "matched_rule": None,
-            "matched_facets": [],
-            "suggestion_entry": None,
-        }
+        return _bytecode_result(
+            contract_address_from_config,
+            contract_name_from_config,
+            status="exact",
+            match=True,
+            has_diff=False,
+        )
 
     base_analysis = analyze_bytecode_diff(
         local_deployed_bytecode,
@@ -262,16 +279,15 @@ def run_bytecode_diff(
         _log_uncovered_bytecode_diff(best_analysis)
         suggestion_entry = build_bytecode_suggestion_entry(best_analysis)
 
-    return {
-        "contract_address": contract_address_from_config,
-        "contract_name": contract_name_from_config,
-        "status": evaluation["status"],
-        "match": evaluation["status"] != "failed",
-        "has_diff": True,
-        "matched_rule": evaluation["matched_rule"],
-        "matched_facets": evaluation["matched_facets"],
-        "suggestion_entry": suggestion_entry,
-    }
+    return _bytecode_result(
+        contract_address_from_config,
+        contract_name_from_config,
+        status=evaluation["status"],
+        match=evaluation["status"] != "failed",
+        matched_rule=evaluation["matched_rule"],
+        matched_facets=evaluation["matched_facets"],
+        suggestion_entry=suggestion_entry,
+    )
 
 
 def run_source_diff(
@@ -638,30 +654,24 @@ def process_config(
                                 any_rule.get("reason"),
                             )
                             bytecode_stats.append(
-                                {
-                                    "contract_address": contract_address,
-                                    "contract_name": contract_name,
-                                    "status": "allowed",
-                                    "match": False,
-                                    "has_diff": True,
-                                    "matched_rule": any_rule,
-                                    "matched_facets": ["any"],
-                                    "suggestion_entry": None,
-                                }
+                                _bytecode_result(
+                                    contract_address,
+                                    contract_name,
+                                    status="allowed",
+                                    match=False,
+                                    matched_rule=any_rule,
+                                    matched_facets=["any"],
+                                )
                             )
                         else:
                             logger.error(str(exc))
                             bytecode_stats.append(
-                                {
-                                    "contract_address": contract_address,
-                                    "contract_name": contract_name,
-                                    "status": "failed",
-                                    "match": False,
-                                    "has_diff": True,
-                                    "matched_rule": None,
-                                    "matched_facets": [],
-                                    "suggestion_entry": None,
-                                }
+                                _bytecode_result(
+                                    contract_address,
+                                    contract_name,
+                                    status="failed",
+                                    match=False,
+                                )
                             )
             except BaseCustomException as custom_exc:
                 ExceptionHandler.raise_exception_or_log(custom_exc)
@@ -864,25 +874,20 @@ def main() -> None:
 
     print_final_summary(all_results, enable_source_comparison, enable_binary_comparison)
 
-    has_unallowed_diffs = any(
+    source_failures = sum(
         stat["status"] == "failed"
         for result in all_results
-        for stat in result["source_stats"] + result["bytecode_stats"]
+        for stat in result["source_stats"]
+    )
+    bytecode_failures = sum(
+        stat["status"] == "failed"
+        for result in all_results
+        for stat in result["bytecode_stats"]
     )
 
     logger.okay(f"Done in {round(execution_time, 3)}s ✨" + " " * 100)
 
-    if has_unallowed_diffs:
-        source_failures = sum(
-            stat["status"] == "failed"
-            for result in all_results
-            for stat in result["source_stats"]
-        )
-        bytecode_failures = sum(
-            stat["status"] == "failed"
-            for result in all_results
-            for stat in result["bytecode_stats"]
-        )
+    if source_failures + bytecode_failures > 0:
         logger.error(
             "Exiting with non-zero code due to unallowed diffs",
             f"source={source_failures}, bytecode={bytecode_failures}",

--- a/diffyscan/utils/binary_verifier.py
+++ b/diffyscan/utils/binary_verifier.py
@@ -135,8 +135,8 @@ def analyze_bytecode_diff(
         local_trimmed["string_literal"] != remote_trimmed["string_literal"]
     )
     metadata_mismatch = local_trimmed["metadata"] != remote_trimmed["metadata"]
-    length_mismatch = len(_strip_prefix(local_runtime)) != len(
-        _strip_prefix(remote_runtime)
+    length_mismatch = len(local_runtime.removeprefix("0x")) != len(
+        remote_runtime.removeprefix("0x")
     )
     exact_match = not (
         runtime_mismatch_ranges
@@ -247,8 +247,8 @@ def _compute_runtime_mismatch_ranges(
     remote_runtime: str,
     immutables: dict[int, int],
 ) -> list[dict]:
-    local_hex = _strip_prefix(local_runtime)
-    remote_hex = _strip_prefix(remote_runtime)
+    local_hex = local_runtime.removeprefix("0x")
+    remote_hex = remote_runtime.removeprefix("0x")
     comparable_byte_count = min(len(local_hex), len(remote_hex)) // 2
 
     ranges = []
@@ -312,8 +312,8 @@ def _collect_immutable_observations(
     remote_runtime: str,
     immutables: dict[int, int],
 ) -> list[dict]:
-    local_hex = _strip_prefix(local_runtime)
-    remote_hex = _strip_prefix(remote_runtime)
+    local_hex = local_runtime.removeprefix("0x")
+    remote_hex = remote_runtime.removeprefix("0x")
     observations = []
 
     for offset, length in sorted(immutables.items()):
@@ -446,7 +446,3 @@ def slice_hex(hex_value: str, offset: int, length: int) -> str:
 
 def _prefix_hex(value: str) -> str:
     return f"0x{value}" if value else ""
-
-
-def _strip_prefix(value: str) -> str:
-    return value[2:] if value.startswith("0x") else value

--- a/diffyscan/utils/common.py
+++ b/diffyscan/utils/common.py
@@ -55,8 +55,7 @@ def _load_yaml_config(config_file, path: str) -> Config:
             f"{path}: configuration root must be a mapping, got {type(config).__name__}"
         )
     _validate_yaml_hex_keys(config, path)
-    _validate_bool_fields(config, path)
-    validate_allowed_diffs_config(config, path)
+    _validate_loaded_config(config, path)
     return config  # type: ignore[return-value]
 
 


### PR DESCRIPTION
This pull request refactors how bytecode result dictionaries are constructed and streamlines related code paths in `diffyscan.py`. It introduces a helper function for building bytecode result objects, applies it throughout the codebase for consistency, and makes minor improvements to hex string handling and configuration validation.

**Bytecode result construction and usage:**
- Introduced a `_bytecode_result` helper function to standardize the creation of bytecode result dictionaries, replacing repeated inline dictionary constructions across the codebase. (`diffyscan/diffyscan.py`)
- Refactored `run_bytecode_diff`, `analysis_provider`, and `process_config` to use the new `_bytecode_result` function, improving code clarity and reducing duplication. (`diffyscan/diffyscan.py`) [[1]](diffhunk://#diff-9801d5f5fc476c20e8bb65e67f88769c661ee5e896bf560f3ac5948ed15e938dL170-R204) [[2]](diffhunk://#diff-9801d5f5fc476c20e8bb65e67f88769c661ee5e896bf560f3ac5948ed15e938dL199-R222) [[3]](diffhunk://#diff-9801d5f5fc476c20e8bb65e67f88769c661ee5e896bf560f3ac5948ed15e938dL265-R286) [[4]](diffhunk://#diff-9801d5f5fc476c20e8bb65e67f88769c661ee5e896bf560f3ac5948ed15e938dL641-R670)

**Hex string handling improvements:**
- Simplified hex prefix removal by replacing the custom `_strip_prefix` function with the built-in `removeprefix("0x")` method in `binary_verifier.py`, and removed the now-unused helper. (`diffyscan/utils/binary_verifier.py`) [[1]](diffhunk://#diff-67a4db2085a1695cbee7c92d7789cbf9df845b95956b9487bb04464ee56c4c08L138-R139) [[2]](diffhunk://#diff-67a4db2085a1695cbee7c92d7789cbf9df845b95956b9487bb04464ee56c4c08L250-R251) [[3]](diffhunk://#diff-67a4db2085a1695cbee7c92d7789cbf9df845b95956b9487bb04464ee56c4c08L315-R316) [[4]](diffhunk://#diff-67a4db2085a1695cbee7c92d7789cbf9df845b95956b9487bb04464ee56c4c08L449-L452)

**Configuration validation:**
- Consolidated YAML configuration validation into a single `_validate_loaded_config` call for improved maintainability. (`diffyscan/utils/common.py`)

**Exit code determination:**
- Adjusted the logic in `main()` to determine non-zero exit codes based on the sum of source and bytecode failures, rather than only bytecode failures. (`diffyscan/diffyscan.py`) [[1]](diffhunk://#diff-9801d5f5fc476c20e8bb65e67f88769c661ee5e896bf560f3ac5948ed15e938dL867-L875) [[2]](diffhunk://#diff-9801d5f5fc476c20e8bb65e67f88769c661ee5e896bf560f3ac5948ed15e938dR883-R886)