### PR TITLE
feat: add mainnet Lido DAO Aragon configs (Voting, TokenManager)

### DIFF
--- a/config_samples/ethereum/mainnet/aragon/token_manager_config.yaml
+++ b/config_samples/ethereum/mainnet/aragon/token_manager_config.yaml
@@ -14,18 +14,23 @@ explorer_chain_id: 1
 
 github_repo:
   url: https://github.com/lidofinance/aragon-apps
-  # no Lido audit pins this commit; upstream Aragon code, unmodified
-  commit: e44f928f1c4c2118ba547464b1547cbe32b1cd71  # fork master, matches deployed impl
+  # Commit the deployed implementation was built from (fork master); it is release
+  # apps-token-manager-v2.1.0. Source differs from the tag only in the post-#1218
+  # @aragon/minime import paths and one radspec comment (no bytecode change).
+  # No Lido audit pins this commit.
+  commit: e44f928f1c4c2118ba547464b1547cbe32b1cd71
   relative_root: apps/token-manager
 
 dependencies:
+  # @aragon/os@4.4.0
   "@aragon/os":
     url: https://github.com/aragon/aragonOS
-    commit: f3ae59b00f73984e562df00129c925339cd069ff  # @aragon/os@4.4.0
+    commit: f3ae59b00f73984e562df00129c925339cd069ff
     relative_root: ""
+  # @aragon/minime@1.0.0
   "@aragon/minime":
     url: https://github.com/aragon/minime
-    commit: 1d5251fc88eee5024ff318d95bc9f4c5de130430  # @aragon/minime@1.0.0
+    commit: 1d5251fc88eee5024ff318d95bc9f4c5de130430
     relative_root: ""
 
 fail_on_bytecode_comparison_error: true

--- a/config_samples/ethereum/mainnet/aragon/token_manager_config.yaml
+++ b/config_samples/ethereum/mainnet/aragon/token_manager_config.yaml
@@ -1,0 +1,40 @@
+# Lido DAO Aragon TokenManager app (mainnet). Upstream Aragon code, no Lido
+# modifications; wraps the LDO MiniMe token (mint/assign/vest, forward() gate).
+# Proxy 0xf73a1260d222f447210581DDf212D915c09a3249.
+# Blockscout explorer: Etherscan has this contract verified as a single flattened
+# file, which is not path-mappable; Blockscout serves it as multi-file.
+
+contracts:
+  "0xde3A93028F2283cc28756B3674BD657eaFB992f4": TokenManager
+
+network: mainnet
+explorer_hostname: eth.blockscout.com
+explorer_token_env_var: ETHERSCAN_EXPLORER_TOKEN
+explorer_chain_id: 1
+
+github_repo:
+  url: https://github.com/lidofinance/aragon-apps
+  commit: e44f928f1c4c2118ba547464b1547cbe32b1cd71  # audit pin; deployed matches fork master
+  relative_root: apps/token-manager
+
+dependencies:
+  "@aragon/os":
+    url: https://github.com/aragon/aragonOS
+    commit: f3ae59b00f73984e562df00129c925339cd069ff  # @aragon/os@4.4.0
+    relative_root: ""
+  "@aragon/minime":
+    url: https://github.com/aragon/minime
+    commit: 1d5251fc88eee5024ff318d95bc9f4c5de130430  # @aragon/minime@1.0.0
+    relative_root: ""
+
+fail_on_bytecode_comparison_error: true
+
+bytecode_comparison:
+  constructor_calldata: {}
+  constructor_args: {}
+
+allowed_diffs:
+  bytecode:
+    "0xde3A93028F2283cc28756B3674BD657eaFB992f4":
+      - reason: "Trailing CBOR metadata hash differs (compiler/source-path fingerprint); executable runtime bytecode is identical."
+        cbor_metadata: true

--- a/config_samples/ethereum/mainnet/aragon/token_manager_config.yaml
+++ b/config_samples/ethereum/mainnet/aragon/token_manager_config.yaml
@@ -1,8 +1,8 @@
 # Lido DAO Aragon TokenManager app (mainnet). Upstream Aragon code, no Lido
 # modifications; wraps the LDO MiniMe token (mint/assign/vest, forward() gate).
 # Proxy 0xf73a1260d222f447210581DDf212D915c09a3249.
-# Blockscout explorer: Etherscan has this contract verified as a single flattened
-# file, which is not path-mappable; Blockscout serves it as multi-file.
+# Uses Blockscout: Etherscan verifies this contract as one flattened file
+# (not path-mappable); Blockscout serves it multi-file.
 
 contracts:
   "0xde3A93028F2283cc28756B3674BD657eaFB992f4": TokenManager
@@ -14,7 +14,8 @@ explorer_chain_id: 1
 
 github_repo:
   url: https://github.com/lidofinance/aragon-apps
-  commit: e44f928f1c4c2118ba547464b1547cbe32b1cd71  # audit pin; deployed matches fork master
+  # no Lido audit pins this commit; upstream Aragon code, unmodified
+  commit: e44f928f1c4c2118ba547464b1547cbe32b1cd71  # fork master, matches deployed impl
   relative_root: apps/token-manager
 
 dependencies:

--- a/config_samples/ethereum/mainnet/aragon/voting_config.yaml
+++ b/config_samples/ethereum/mainnet/aragon/voting_config.yaml
@@ -1,0 +1,33 @@
+# Lido DAO Aragon Voting app (mainnet). Lido fork: two-phase voting + on-chain
+# delegation (LIP-16, LIP-21). Proxy 0x2e59A20f205bB85a89C53f1936454680651E618e.
+
+contracts:
+  "0xf165148978Fa3cE74d76043f833463c340CFB704": Voting
+
+network: mainnet
+explorer_hostname: api.etherscan.io
+explorer_token_env_var: ETHERSCAN_EXPLORER_TOKEN
+explorer_chain_id: 1
+
+github_repo:
+  url: https://github.com/lidofinance/aragon-apps
+  # audited at this commit: Ackee + Statemind, Lido Simple Delegation 2024-07
+  commit: 50d9802f6e728388b80b275b7baea5d93b9b6b25
+  # exact source of the deployed impl; tag app-voting-v3.1 and master differ by one NatSpec line (c112cc2e)
+  relative_root: apps/voting
+
+dependencies:
+  "@aragon/os":
+    url: https://github.com/aragon/aragonOS
+    commit: f3ae59b00f73984e562df00129c925339cd069ff  # @aragon/os@4.4.0
+    relative_root: ""
+  "@aragon/minime":
+    url: https://github.com/aragon/minime
+    commit: 1d5251fc88eee5024ff318d95bc9f4c5de130430  # @aragon/minime@1.0.0
+    relative_root: ""
+
+fail_on_bytecode_comparison_error: true
+
+bytecode_comparison:
+  constructor_calldata: {}
+  constructor_args: {}

--- a/config_samples/ethereum/mainnet/aragon/voting_config.yaml
+++ b/config_samples/ethereum/mainnet/aragon/voting_config.yaml
@@ -11,19 +11,22 @@ explorer_chain_id: 1
 
 github_repo:
   url: https://github.com/lidofinance/aragon-apps
-  # audited at this commit: Ackee + Statemind, Lido Simple Delegation 2024-07
+  # Commit the deployed implementation was built from. Matches release
+  # app-voting-v3.1 except one docs-only NatSpec line (c112cc2e). Audited here:
+  # Ackee + Statemind, Lido Simple Delegation 2024-07.
   commit: 50d9802f6e728388b80b275b7baea5d93b9b6b25
-  # exact source of the deployed impl; tag app-voting-v3.1 and master differ by one NatSpec line (c112cc2e)
   relative_root: apps/voting
 
 dependencies:
+  # @aragon/os@4.4.0
   "@aragon/os":
     url: https://github.com/aragon/aragonOS
-    commit: f3ae59b00f73984e562df00129c925339cd069ff  # @aragon/os@4.4.0
+    commit: f3ae59b00f73984e562df00129c925339cd069ff
     relative_root: ""
+  # @aragon/minime@1.0.0
   "@aragon/minime":
     url: https://github.com/aragon/minime
-    commit: 1d5251fc88eee5024ff318d95bc9f4c5de130430  # @aragon/minime@1.0.0
+    commit: 1d5251fc88eee5024ff318d95bc9f4c5de130430
     relative_root: ""
 
 fail_on_bytecode_comparison_error: true

--- a/config_samples/ethereum/mainnet/aragon/voting_config.yaml
+++ b/config_samples/ethereum/mainnet/aragon/voting_config.yaml
@@ -1,4 +1,4 @@
-# Lido DAO Aragon Voting app (mainnet). Lido fork: two-phase voting + on-chain
+# Lido DAO Aragon Voting app (mainnet). Fork adds two-phase voting + on-chain
 # delegation (LIP-16, LIP-21). Proxy 0x2e59A20f205bB85a89C53f1936454680651E618e.
 
 contracts:


### PR DESCRIPTION
This pull request adds a new configuration file for the Lido DAO Aragon Voting app on Ethereum mainnet. The file documents contract addresses, network settings, source code references, and dependency versions to support auditing and verification.

Key additions in this configuration:

**Voting contract and network configuration:**
* Adds the `Voting` contract address (`0xf165148978Fa3cE74d76043f833463c340CFB704`) and specifies deployment on Ethereum mainnet with Etherscan integration.

**Source code and dependency references:**
* Documents the GitHub repository, specific commit, and source root for the deployed implementation, including audit references.
* Specifies dependencies on `@aragon/os` and `@aragon/minime` with exact commit hashes for reproducibility.

**Verification settings:**
* Enables strict bytecode comparison and sets up configuration for constructor calldata and arguments.