### PR TITLE
Fix bytecode comparison issues

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -41,6 +41,8 @@ jobs:
             network: mainnet
           - config: config_samples/ethereum/mainnet/tw/tw_easy_track_config.json
             network: mainnet
+          - config: config_samples/ethereum/mainnet/csm/csm_config.json
+            network: mainnet
           - config: config_samples/ethereum/hoodi/vaults/hoodi_vaults_testnet_config.json
             network: hoodi
           - config: config_samples/ethereum/hoodi/vaults/hoodi_vaults_easy_track_config.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ explorer_token_env_var: "ETHERSCAN_EXPLORER_TOKEN"
 github_repo:        { url, commit, relative_root }
 dependencies:       { "dep_name": { url, commit, relative_root } }
 bytecode_comparison: { constructor_calldata, constructor_args, libraries, deployment_from, extra_sources }
+                    # libraries keyed by the library's DEFINITION file: { "src/lib/Foo.sol": { "Foo": "0xaddr" } }
+                    # explorer-provided libraries are auto-detected and re-keyed to the definition file for solc linking
 allowed_diffs:      { bytecode: {...}, source: {...} }  # optional; see below
 ```
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,29 @@ Recommended workflow to tighten a wildcard:
 2. Copy the `allowed_diffs` snippet it prints for the uncovered diff.
 3. Paste it into the config, replace the placeholder `reason` with the real explanation, and re-run to confirm it now passes.
 
+#### Linked libraries
+
+Contracts that use external (deployment-linked) libraries need those library
+addresses to recompile identical bytecode. Diffyscan reads them from the
+explorer metadata automatically and links them, so a manual override is rarely
+needed. When you do provide them, use `bytecode_comparison.libraries`, **keyed
+by the file that _defines_ the library** (this is how `solc` links placeholders):
+
+```json
+"bytecode_comparison": {
+  "libraries": {
+    "src/lib/AssetRecovererLib.sol": {
+      "AssetRecovererLib": "0x37ada408ae3c3992953688e2ccb9ee7a3dfda902"
+    }
+  }
+}
+```
+
+> **Troubleshooting:** if deployment simulation fails with `Invalid params` or
+> diffyscan reports `unlinked libraries`, a library address is missing or was
+> keyed by the wrong file — add it under `bytecode_comparison.libraries` keyed by
+> its definition file.
+
 Start the script
 
 ```bash

--- a/config_samples/ethereum/mainnet/csm/csm_config.json
+++ b/config_samples/ethereum/mainnet/csm/csm_config.json
@@ -1,0 +1,38 @@
+{
+    "contracts": {
+        "0x107d287f178cd54792614d7d63c47d8242240bed": "ParametersRegistry",
+        "0xe768572cc5ae5c698345c59288d871a949ea8bd3": "Accounting",
+        "0x66adb8b3f58d3dfdf6badb595e41f19e947e5c14": "VettedGate",
+        "0xc0f110af6ea9119037a71c84d14506a22ae43dde": "MerkleGateFactory",
+        "0xece6e0cde61078f76b66ef0c338a6875e5d01f79": "FeeOracle",
+        "0x936da7cdb7eed1084d294e23ea1d7ad72dccfe0e": "FeeDistributor",
+        "0x63992a86f009fcc796a8369feefb68880aef4e3a": "CSModule",
+        "0xd25e7c3923d2e68c325980b0e15ed20d62b2691f": "ValidatorStrikes",
+        "0xa5b9e96e951089e629ab0834aeaf242a81394ea0": "ExitPenalties",
+        "0x610b517d380f287c239c93f8ef6ffbd567aa4ba5": "Ejector",
+        "0xb8cd8f059ad7a5db8cafde34aab007317f7156c8": "PermissionlessGate",
+        "0x711985e069f4d702e0457c0dacade3d3894ce4e3": "OneShotCurveSetup",
+        "0xfce7ab839e55de77730716d05b3553e45ab3a5ba": "Verifier"
+    },
+    "explorer_hostname": "api.etherscan.io",
+    "explorer_chain_id": 1,
+    "explorer_token_env_var": "ETHERSCAN_EXPLORER_TOKEN",
+    "github_repo": {
+        "url": "https://github.com/lidofinance/staking-modules",
+        "commit": "4d3de6658499e1c1774951780a97d7ae25ca18b8",
+        "relative_root": ""
+    },
+    "dependencies": {
+        "node_modules/@openzeppelin/contracts": {
+            "url": "https://github.com/OpenZeppelin/openzeppelin-contracts",
+            "commit": "c64a1ed",
+            "relative_root": "contracts"
+        },
+        "node_modules/@openzeppelin/contracts-upgradeable": {
+            "url": "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable",
+            "commit": "e725abd",
+            "relative_root": "contracts"
+        }
+    },
+    "fail_on_bytecode_comparison_error": true
+}

--- a/diffyscan/utils/explorer.py
+++ b/diffyscan/utils/explorer.py
@@ -413,12 +413,16 @@ def _parse_libraries(
         parsed: dict[str, dict[str, str]] = {}
         for key, value in raw_libraries.items():
             if isinstance(value, dict):
-                parsed.setdefault(key, {})
                 for lib_name, address in value.items():
-                    parsed[key][lib_name] = _normalize_library_address(address)
+                    path = _resolve_library_definition_path(
+                        lib_name, str(key), source_files
+                    )
+                    parsed.setdefault(path, {})
+                    parsed[path][lib_name] = _normalize_library_address(address)
                 continue
 
             path, lib_name = _parse_qualified_library_name(str(key), source_files)
+            path = _resolve_library_definition_path(lib_name, path, source_files)
             parsed.setdefault(path, {})
             parsed[path][lib_name] = _normalize_library_address(value)
         return parsed or None
@@ -478,6 +482,7 @@ def _parse_libraries(
                 raise ExplorerError(f"Unsupported library entry: {part}")
 
             path, lib_name = _parse_qualified_library_name(qualified_name, source_files)
+            path = _resolve_library_definition_path(lib_name, path, source_files)
             parsed.setdefault(path, {})
             parsed[path][lib_name] = _normalize_library_address(address)
 
@@ -525,6 +530,24 @@ def _infer_library_path(library_name: str, source_files: dict) -> str:
     raise ExplorerError(
         f"Multiple source files declare library '{library_name}': {matches}"
     )
+
+
+def _resolve_library_definition_path(
+    library_name: str, fallback_path: str, source_files: dict
+) -> str:
+    """Return the source path that DEFINES the library.
+
+    solc keys library link placeholders by the library's definition file, but
+    explorers (notably Etherscan's ``settings.libraries``) often key them by the
+    importing file, which solc cannot match -- leaving ``__$…$__`` placeholders
+    that make the deployment-simulation eth_call fail with an opaque
+    "Invalid params". Re-derive the definition path from source; fall back to the
+    explorer-provided path when it cannot be uniquely inferred.
+    """
+    try:
+        return _infer_library_path(library_name, source_files)
+    except ExplorerError:
+        return fallback_path
 
 
 def _normalize_library_address(address: str) -> str:
@@ -719,7 +742,31 @@ def compile_contract_from_explorer(
         compiled_contracts, target_contract_name
     )
 
+    _assert_libraries_linked(compiled_contract, target_contract_name)
+
     return compiled_contract
+
+
+def _assert_libraries_linked(compiled_contract: dict, contract_name: str) -> None:
+    """Fail early if solc left unlinked library placeholders in the creation
+    bytecode. They are invalid hex, so the deployment-simulation eth_call would
+    otherwise fail with an opaque "Invalid params" from the RPC node."""
+    link_references = (
+        compiled_contract.get("evm", {}).get("bytecode", {}).get("linkReferences")
+    )
+    if not link_references:  # None or {} -> fully linked
+        return
+
+    unlinked = sorted(
+        f"{path}:{name}"
+        for path, libraries in link_references.items()
+        for name in libraries
+    )
+    raise CompileError(
+        f"Contract '{contract_name}' has unlinked libraries: {', '.join(unlinked)}. "
+        "Add their addresses to bytecode_comparison.libraries, keyed by each "
+        "library's definition file."
+    )
 
 
 def parse_compiled_contract(

--- a/diffyscan/utils/node_handler.py
+++ b/diffyscan/utils/node_handler.py
@@ -5,7 +5,10 @@ from .logger import logger
 from .custom_exceptions import DeploymentSimulationError, NodeError
 
 DEFAULT_CALLER = "0x0000000000000000000000000000000000000000"
-DEFAULT_DEPLOYMENT_GAS_LIMIT = 100_000_000
+# EIP-7825 (Fusaka): max gas a single tx / contract creation may use. No real
+# deployment can exceed this, so it is the correct simulation ceiling; values
+# above it are rejected by strict/hosted nodes with an opaque "Invalid params".
+DEFAULT_DEPLOYMENT_GAS_LIMIT = 16_777_216  # 2**24
 
 
 def _rpc_call(rpc_url: str, method: str, params: list):

--- a/tests/test_bytecode_metadata.py
+++ b/tests/test_bytecode_metadata.py
@@ -5,11 +5,16 @@ import pytest
 from diffyscan.utils.calldata import get_calldata
 from diffyscan.utils.custom_exceptions import CalldataError, CompileError, NodeError
 from diffyscan.utils.explorer import (
+    _assert_libraries_linked,
     _get_contract_from_blockscout,
     _get_contract_from_etherscan,
+    _parse_libraries,
     compile_contract_from_explorer,
 )
-from diffyscan.utils.node_handler import simulate_deployment
+from diffyscan.utils.node_handler import (
+    DEFAULT_DEPLOYMENT_GAS_LIMIT,
+    simulate_deployment,
+)
 
 
 class DummyResponse:
@@ -137,7 +142,10 @@ def test_simulate_deployment_uses_default_gas_limit(monkeypatch):
 
     simulate_deployment("0x6001", "https://rpc.example")
 
-    assert captured["payload"]["params"][0]["gas"] == hex(100_000_000)
+    # EIP-7825: default must not exceed the per-tx gas cap (2**24).
+    assert DEFAULT_DEPLOYMENT_GAS_LIMIT == 16_777_216
+    assert captured["payload"]["params"][0]["gas"] == hex(16_777_216)
+    assert int(captured["payload"]["params"][0]["gas"], 16) <= 2**24
 
 
 def test_simulate_deployment_uses_custom_gas_limit(monkeypatch):
@@ -435,3 +443,128 @@ def test_compile_contract_from_explorer_redownloads_tampered_cached_compiler(
 
     assert result == {"abi": [], "evm": {}}
     assert calls["prepare"] == 1
+
+
+# --- Fix A: re-key explorer libraries by definition file --------------------
+
+_ACCOUNTING_SOURCES = {
+    "src/Accounting.sol": {
+        "content": "import './lib/AssetRecovererLib.sol'; contract Accounting {}"
+    },
+    "src/lib/AssetRecovererLib.sol": {
+        "content": "library AssetRecovererLib { function recover() external {} }"
+    },
+}
+
+
+def test_parse_libraries_rekeys_importing_file_to_definition_file():
+    # Etherscan settings.libraries keys libs by the IMPORTING file, but solc
+    # links placeholders by the DEFINITION file. The result must be re-keyed.
+    parsed = _parse_libraries(
+        {
+            "src/Accounting.sol": {
+                "AssetRecovererLib": "0x37ada408ae3c3992953688e2ccb9ee7a3dfda902"
+            }
+        },
+        _ACCOUNTING_SOURCES,
+    )
+
+    assert parsed == {
+        "src/lib/AssetRecovererLib.sol": {
+            "AssetRecovererLib": "0x37ada408ae3c3992953688e2ccb9ee7a3dfda902"
+        }
+    }
+
+
+def test_parse_libraries_falls_back_when_definition_not_found():
+    # No source declares the library -> keep the explorer-provided key.
+    parsed = _parse_libraries(
+        {
+            "contracts/Consumer.sol": {
+                "Helper": "0x1111111111111111111111111111111111111111"
+            }
+        },
+        {"contracts/Consumer.sol": {"content": "contract Consumer {}"}},
+    )
+
+    assert parsed == {
+        "contracts/Consumer.sol": {
+            "Helper": "0x1111111111111111111111111111111111111111"
+        }
+    }
+
+
+def test_get_contract_from_etherscan_rekeys_standard_json_libraries(monkeypatch):
+    standard_json = json.dumps(
+        {
+            "language": "Solidity",
+            "sources": _ACCOUNTING_SOURCES,
+            "settings": {
+                "libraries": {
+                    "src/Accounting.sol": {
+                        "AssetRecovererLib": "0x37ada408ae3c3992953688e2ccb9ee7a3dfda902"
+                    }
+                }
+            },
+        }
+    )
+
+    def fake_fetch(url):
+        return DummyResponse(
+            {
+                "message": "OK",
+                "result": [
+                    {
+                        "ContractName": "Accounting",
+                        "CompilerVersion": "v0.8.33+commit.64118f21",
+                        "SourceCode": "{" + standard_json + "}",
+                        "OptimizationUsed": "1",
+                        "Runs": "200",
+                        "EVMVersion": "osaka",
+                        "Library": "",
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr("diffyscan.utils.explorer.fetch", fake_fetch)
+
+    contract = _get_contract_from_etherscan(
+        None,
+        "api.etherscan.io",
+        "0x0000000000000000000000000000000000000001",
+    )
+
+    assert contract["libraries"] == {
+        "src/lib/AssetRecovererLib.sol": {
+            "AssetRecovererLib": "0x37ada408ae3c3992953688e2ccb9ee7a3dfda902"
+        }
+    }
+
+
+# --- Fix B: unlinked-library guard ------------------------------------------
+
+
+def test_assert_libraries_linked_raises_on_unlinked():
+    compiled = {
+        "evm": {
+            "bytecode": {
+                "object": "6080__$...$__",
+                "linkReferences": {
+                    "src/lib/AssetRecovererLib.sol": {
+                        "AssetRecovererLib": [{"start": 10, "length": 20}]
+                    }
+                },
+            }
+        }
+    }
+
+    with pytest.raises(CompileError, match="unlinked libraries"):
+        _assert_libraries_linked(compiled, "Accounting")
+
+
+def test_assert_libraries_linked_passes_when_linked():
+    # Empty or missing linkReferences means fully linked -> no error.
+    _assert_libraries_linked({"evm": {"bytecode": {"linkReferences": {}}}}, "Demo")
+    _assert_libraries_linked({"evm": {"bytecode": {}}}, "Demo")
+    _assert_libraries_linked({"evm": {}}, "Demo")


### PR DESCRIPTION
Adds a config sample for the new CSMv3 mainnet deployment and fixes three issues that stopped diffyscan from reproducing library-linked contracts bytecode comparison. 

Closes #181.

### Issue breakdown

Verifying the CSM contracts surfaced three separate blockers, each producing a confusing failure:

1. **Explorer library addresses were keyed by the wrong file.** Etherscan reports linked libraries keyed by the file that *imports* them, but `solc` links placeholders by the file that *defines* them. The addresses were fetched correctly but never applied, so recompiled bytecode kept its `__$…$__` placeholders.

2. **Unlinked placeholders failed with an opaque error.** Those leftover placeholders are invalid hex, so the deployment-simulation `eth_call` came back as a bare `Invalid params` from the node — no hint that a library was missing.

3. **The 100M gas limit exceeded the EIP-7825 cap.** Fusaka caps a single tx/creation at 2²⁴ gas; strict nodes may rightfully reject anything higher, again as `Invalid params`.

### Fixes suggested with this PR

- **Re-key explorer libraries to their definition file** by inferring it from the source set, falling back to the explorer-provided key when it can't be resolved uniquely. Contracts with linked libraries now verify with **no manual config**.
- **Fail fast on unlinked libraries** with a message naming each one and how to fix it, instead of the opaque RPC error.
- **Lower the deployment-simulation gas limit to 16,777,216 (2²⁴)** — the EIP-7825 ceiling, which no real deployment can exceed.

### Verified

All 13 CSM contracts reproduce and match on-chain bytecode end-to-end (constructor simulation included) with zero manual overrides. Added unit tests for the re-keying, the fallback, and the unlinked-library guard; updated the gas-limit test. 

Wired the config into the regression matrix.
