### PR TITLE
feat: add local_compilation mode for explorer-unverified contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,9 @@ explorer_token_env_var: "ETHERSCAN_EXPLORER_TOKEN"
 github_repo:        { url, commit, relative_root }
 dependencies:       { "dep_name": { url, commit, relative_root } }
 bytecode_comparison: { constructor_calldata, constructor_args, libraries, deployment_from, extra_sources }
+local_compilation:  { compiler, inputs }  # optional; bytecode-only checks for explorer-unverified contracts
+                    # compiler: full solc build string ("v0.8.20+commit.a1b79de6"); inputs: { "0xaddr": "path/to/solc-input.json" } relative to the config file
+                    # the input supplies the source manifest + settings; contents still come from GitHub; source diff is skipped for these addresses
                     # libraries keyed by the library's DEFINITION file: { "src/lib/Foo.sol": { "Foo": "0xaddr" } }
                     # explorer-provided libraries are auto-detected and re-keyed to the definition file for solc linking
 allowed_diffs:      { bytecode: {...}, source: {...} }  # optional; see below

--- a/README.md
+++ b/README.md
@@ -171,6 +171,29 @@ dependencies:
 
 > **Important:** In YAML configs, always quote contract addresses (e.g. `"0x1234..."`). Unquoted hex values will be parsed as integers by YAML, and diffyscan will raise an error if this happens.
 
+### Unverified contracts (`local_compilation`)
+
+Contracts with no explorer-verified source can still be checked at the bytecode
+level: supply a solc standard-JSON input file per address plus the exact
+compiler build. The input file provides the source-file manifest and compiler
+settings only — file contents are still fetched from the pinned GitHub
+repo/commit, so the check stays honest. The source diff is skipped for these
+contracts (there is nothing explorer-side to diff against); they are verified
+by the bytecode comparison alone.
+
+```yaml
+local_compilation:
+  compiler: v0.8.20+commit.a1b79de6   # full build string, required
+  inputs:                             # address -> solc input, relative to this config file
+    "0x4c8c4A15c1e810e481c412A9B06Be5f79dC02192": inputs/proxy-admin.json
+```
+
+A byte-for-byte match **including the CBOR metadata tail** proves the guessed
+source and settings are exactly right — the metadata hash covers both. A match
+that only passes with `allowed_diffs` rules such as `cbor_metadata` is much
+weaker evidence for an unverified contract, since there is no explorer anchor;
+prefer configurations that reproduce the deployed bytecode in full.
+
 ### Granular allowlists
 
 Use `allowed_diffs` to describe exactly which differences are expected. The same schema works in JSON and YAML.

--- a/diffyscan/diffyscan.py
+++ b/diffyscan/diffyscan.py
@@ -34,6 +34,7 @@ from .utils.custom_exceptions import (
     ExceptionHandler,
 )
 from .utils.explorer import (
+    build_contract_from_local_input,
     compile_contract_from_explorer,
     get_contract_from_explorer,
     get_explorer_chain_id,
@@ -509,6 +510,22 @@ def _load_explorer_token(config: dict) -> str:
     raise ValueError(error_msg)
 
 
+def _get_local_inputs(config: dict, config_path: str) -> dict[str, str]:
+    """Map lowercased address -> absolute solc-input path from local_compilation.
+
+    Paths are resolved relative to the config file directory.
+    """
+    local_compilation = config.get("local_compilation") or {}
+    inputs = local_compilation.get("inputs") or {}
+    base_dir = os.path.dirname(os.path.abspath(config_path))
+    resolved = {}
+    for address, input_path in inputs.items():
+        if not os.path.isabs(input_path):
+            input_path = os.path.join(base_dir, input_path)
+        resolved[address.lower()] = input_path
+    return resolved
+
+
 def _setup_binary_comparison(config: dict) -> str:
     """Load RPC URL and configure exception handling for bytecode comparison."""
     rpc_env_var = config.get("rpc_url_env_var", "REMOTE_RPC_URL")
@@ -603,7 +620,33 @@ def process_config(
     config: dict = load_config(path)  # type: ignore[assignment]
     effective_allowed_diffs = build_effective_allowed_diffs(config)
 
-    explorer_token = _load_explorer_token(config)
+    # Contracts whose sources/settings come from a local solc input, not an explorer
+    local_inputs = _get_local_inputs(config, path)
+    local_compiler = (config.get("local_compilation") or {}).get("compiler")
+    if local_inputs and not local_compiler:
+        raise CompileError(
+            'Config "local_compilation.compiler" is required when '
+            '"local_compilation.inputs" is set (e.g. "v0.8.26+commit.8a97fa7a")'
+        )
+    unknown_local = sorted(
+        set(local_inputs) - {address.lower() for address in config["contracts"]}
+    )
+    if unknown_local:
+        logger.warn(
+            '"local_compilation.inputs" addresses missing from "contracts"',
+            ", ".join(unknown_local),
+        )
+    if local_inputs and not enable_binary_comparison:
+        logger.warn(
+            "local_compilation contracts are checked by bytecode comparison only; "
+            "with --skip-binary-comparison they are not verified at all"
+        )
+
+    # The explorer token is only needed when some contract still uses the explorer
+    needs_explorer = any(
+        address.lower() not in local_inputs for address in config["contracts"]
+    )
+    explorer_token = _load_explorer_token(config) if needs_explorer else None
     github_api_token = load_env("GITHUB_API_TOKEN", masked=True, required=True)
 
     remote_rpc_url = None
@@ -628,10 +671,12 @@ def process_config(
             logger.okay("Remote chain ID", remote_chain_id)
 
         explorer_hostname = config.get("explorer_hostname")
-        if explorer_hostname is None:
-            logger.warn('Failed to find "explorer_hostname" in the config')
-        assert explorer_hostname is not None, "explorer_hostname is required"
-        explorer_chain_id = get_explorer_chain_id(config)
+        explorer_chain_id = None
+        if needs_explorer:
+            if explorer_hostname is None:
+                logger.warn('Failed to find "explorer_hostname" in the config')
+            assert explorer_hostname is not None, "explorer_hostname is required"
+            explorer_chain_id = get_explorer_chain_id(config)
 
         # Apply contract filter if specified
         filter_set = (
@@ -643,14 +688,23 @@ def process_config(
                 continue
             matched_count += 1
             try:
-                contract_code = get_contract_from_explorer(
-                    explorer_token,
-                    explorer_hostname,
-                    contract_address,
-                    contract_name,
-                    explorer_chain_id,
-                    cache_explorer,
-                )
+                local_input_path = local_inputs.get(contract_address.lower())
+                if local_input_path:
+                    logger.info(
+                        f"Building {contract_address} from local solc input {local_input_path}"
+                    )
+                    contract_code = build_contract_from_local_input(
+                        contract_name, local_input_path, local_compiler
+                    )
+                else:
+                    contract_code = get_contract_from_explorer(
+                        explorer_token,
+                        explorer_hostname,
+                        contract_address,
+                        contract_name,
+                        explorer_chain_id,
+                        cache_explorer,
+                    )
 
                 address_key = contract_address.lower()
                 source_rules = effective_allowed_diffs["source"].get(address_key, [])
@@ -658,7 +712,13 @@ def process_config(
                     address_key, []
                 )
 
-                if enable_source_comparison:
+                if enable_source_comparison and local_input_path:
+                    logger.warn(
+                        "Source comparison skipped: local solc input has no "
+                        "explorer-verified source to diff against",
+                        contract_address,
+                    )
+                if enable_source_comparison and not local_input_path:
                     source_result = run_source_diff(
                         contract_address,
                         contract_code,

--- a/diffyscan/diffyscan.py
+++ b/diffyscan/diffyscan.py
@@ -628,13 +628,12 @@ def process_config(
             'Config "local_compilation.compiler" is required when '
             '"local_compilation.inputs" is set (e.g. "v0.8.26+commit.8a97fa7a")'
         )
-    unknown_local = sorted(
-        set(local_inputs) - {address.lower() for address in config["contracts"]}
-    )
+    contract_addresses = {address.lower() for address in config["contracts"]}
+    unknown_local = sorted(set(local_inputs) - contract_addresses)
     if unknown_local:
-        logger.warn(
-            '"local_compilation.inputs" addresses missing from "contracts"',
-            ", ".join(unknown_local),
+        raise ValueError(
+            '"local_compilation.inputs" addresses missing from "contracts": '
+            + ", ".join(unknown_local)
         )
     if local_inputs and not enable_binary_comparison:
         logger.warn(
@@ -642,10 +641,16 @@ def process_config(
             "with --skip-binary-comparison they are not verified at all"
         )
 
-    # The explorer token is only needed when some contract still uses the explorer
-    needs_explorer = any(
-        address.lower() not in local_inputs for address in config["contracts"]
+    # Apply contract filter if specified
+    filter_set = (
+        set(addr.lower() for addr in contract_filter) if contract_filter else None
     )
+    contracts_in_scope = (
+        contract_addresses & filter_set if filter_set else contract_addresses
+    )
+
+    # The explorer token is only needed when some in-scope contract uses the explorer
+    needs_explorer = any(address not in local_inputs for address in contracts_in_scope)
     explorer_token = _load_explorer_token(config) if needs_explorer else None
     github_api_token = load_env("GITHUB_API_TOKEN", masked=True, required=True)
 
@@ -678,17 +683,13 @@ def process_config(
             assert explorer_hostname is not None, "explorer_hostname is required"
             explorer_chain_id = get_explorer_chain_id(config)
 
-        # Apply contract filter if specified
-        filter_set = (
-            set(addr.lower() for addr in contract_filter) if contract_filter else None
-        )
-
         for contract_address, contract_name in config["contracts"].items():
-            if filter_set and contract_address.lower() not in filter_set:
+            address_key = contract_address.lower()
+            if filter_set and address_key not in filter_set:
                 continue
             matched_count += 1
             try:
-                local_input_path = local_inputs.get(contract_address.lower())
+                local_input_path = local_inputs.get(address_key)
                 if local_input_path:
                     logger.info(
                         f"Building {contract_address} from local solc input {local_input_path}"
@@ -706,30 +707,44 @@ def process_config(
                         cache_explorer,
                     )
 
-                address_key = contract_address.lower()
                 source_rules = effective_allowed_diffs["source"].get(address_key, [])
                 bytecode_rules = effective_allowed_diffs["bytecode"].get(
                     address_key, []
                 )
 
-                if enable_source_comparison and local_input_path:
-                    logger.warn(
-                        "Source comparison skipped: local solc input has no "
-                        "explorer-verified source to diff against",
-                        contract_address,
-                    )
-                if enable_source_comparison and not local_input_path:
-                    source_result = run_source_diff(
-                        contract_address,
-                        contract_code,
-                        config,
-                        github_api_token,
-                        source_rules,
-                        recursive_parsing,
-                        cache_github,
-                        skip_user_input,
-                    )
-                    source_stats.append(source_result)
+                if enable_source_comparison:
+                    if local_input_path:
+                        logger.warn(
+                            "Source comparison skipped: local solc input has no "
+                            "explorer-verified source to diff against",
+                            contract_address,
+                        )
+                        if source_rules:
+                            logger.warn(
+                                '"allowed_diffs.source" rules have no effect for '
+                                "local_compilation contracts",
+                                contract_address,
+                            )
+                        source_stats.append(
+                            {
+                                "contract_address": contract_address,
+                                "contract_name": contract_name,
+                                "status": "skipped",
+                                "files_with_diffs": 0,
+                            }
+                        )
+                    else:
+                        source_result = run_source_diff(
+                            contract_address,
+                            contract_code,
+                            config,
+                            github_api_token,
+                            source_rules,
+                            recursive_parsing,
+                            cache_github,
+                            skip_user_input,
+                        )
+                        source_stats.append(source_result)
 
                 if enable_binary_comparison:
                     try:
@@ -1051,6 +1066,7 @@ def _print_source_summary(all_results: list[dict]) -> None:
     total_contracts = len(source_stats)
     exact_matches = sum(stat["status"] == "exact" for stat in source_stats)
     allowed_diffs = sum(stat["status"] == "allowed" for stat in source_stats)
+    skipped = sum(stat["status"] == "skipped" for stat in source_stats)
     failed_diffs = [stat for stat in source_stats if stat["status"] == "failed"]
     total_files_with_diffs = sum(stat["files_with_diffs"] for stat in source_stats)
 
@@ -1059,6 +1075,8 @@ def _print_source_summary(all_results: list[dict]) -> None:
     logger.okay(f"Total contracts analyzed: {total_contracts}")
     logger.okay(f"Exact matches: {exact_matches}")
     logger.okay(f"Allowed diffs: {allowed_diffs}")
+    if skipped:
+        logger.okay(f"Skipped (local_compilation, bytecode-only): {skipped}")
     logger.okay(f"Failures: {len(failed_diffs)}")
     logger.okay(f"Total files with non-zero diffs: {total_files_with_diffs}")
 

--- a/diffyscan/utils/common.py
+++ b/diffyscan/utils/common.py
@@ -160,6 +160,14 @@ def _validate_yaml_hex_keys(config: dict, path: str) -> None:
                             ),
                         )
 
+    local_compilation = config.get("local_compilation")
+    if isinstance(local_compilation, dict):
+        _validate_yaml_address_keys(
+            local_compilation.get("inputs"),
+            path,
+            "local_compilation.inputs",
+        )
+
     allowed_diffs = config.get("allowed_diffs")
     if not isinstance(allowed_diffs, dict):
         return

--- a/diffyscan/utils/custom_types.py
+++ b/diffyscan/utils/custom_types.py
@@ -67,6 +67,14 @@ class GithubRepo(TypedDict):
     relative_root: str
 
 
+class LocalCompilation(TypedDict):
+    # full solc build string, e.g. "v0.8.26+commit.8a97fa7a"
+    compiler: str
+    # contract address -> path of its solc standard-JSON input file,
+    # resolved relative to the config file
+    inputs: dict[str, str]
+
+
 class Config(TypedDict):
     contracts: dict[str, str]
     network: NotRequired[str]
@@ -79,6 +87,7 @@ class Config(TypedDict):
     rpc_url_env_var: NotRequired[str]
     deployment_gas_limit: NotRequired[int]
     bytecode_comparison: NotRequired[BinaryConfig]
+    local_compilation: NotRequired[LocalCompilation]
     allowed_diffs: NotRequired[AllowedDiffsConfig]
     fail_on_bytecode_comparison_error: NotRequired[bool]
     source_comparison: NotRequired[bool]

--- a/diffyscan/utils/explorer.py
+++ b/diffyscan/utils/explorer.py
@@ -694,6 +694,35 @@ def get_contract_from_explorer(
     return result
 
 
+def build_contract_from_local_input(
+    contract_name: str,
+    input_path: str,
+    compiler: str,
+) -> dict:
+    """Build a contract payload from a local solc standard-JSON input file.
+
+    Produces the same shape as get_contract_from_explorer, for contracts with
+    no verified source on the explorer. The input file supplies the source
+    manifest and compiler settings; file contents are refetched from GitHub
+    for the bytecode comparison, so only an exact recompilation can pass.
+    """
+    try:
+        with open(input_path) as f:
+            solc_input = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ExplorerError(
+            f"Failed to read local solc input {input_path}: {exc}"
+        ) from exc
+
+    if not isinstance(solc_input, dict) or not solc_input.get("sources"):
+        raise ExplorerError(f'Local solc input {input_path} has no "sources"')
+
+    solc_input.setdefault("settings", {})[
+        "outputSelection"
+    ] = _default_output_selection()
+    return _build_contract_payload(contract_name, compiler, solc_input)
+
+
 def compile_contract_from_explorer(
     contract_code: dict,
     libraries: dict | None = None,

--- a/diffyscan/utils/explorer.py
+++ b/diffyscan/utils/explorer.py
@@ -717,9 +717,11 @@ def build_contract_from_local_input(
     if not isinstance(solc_input, dict) or not solc_input.get("sources"):
         raise ExplorerError(f'Local solc input {input_path} has no "sources"')
 
-    solc_input.setdefault("settings", {})[
-        "outputSelection"
-    ] = _default_output_selection()
+    settings = solc_input.get("settings")
+    if not isinstance(settings, dict):
+        settings = {}
+        solc_input["settings"] = settings
+    settings["outputSelection"] = _default_output_selection()
     return _build_contract_payload(contract_name, compiler, solc_input)
 
 

--- a/tests/test_local_compilation.py
+++ b/tests/test_local_compilation.py
@@ -1,0 +1,89 @@
+import json
+
+import pytest
+
+from diffyscan.diffyscan import _get_local_inputs
+from diffyscan.utils.custom_exceptions import ExplorerError
+from diffyscan.utils.explorer import build_contract_from_local_input
+
+
+def _write_standard_json(tmp_path, **settings):
+    payload = {
+        "language": "Solidity",
+        "sources": {"contracts/Foo.sol": {"content": "contract Foo {}"}},
+        "settings": settings,
+    }
+    path = tmp_path / "input.json"
+    path.write_text(json.dumps(payload))
+    return str(path)
+
+
+def test_build_contract_from_local_input_shape(tmp_path):
+    path = _write_standard_json(tmp_path, evmVersion="cancun")
+    contract = build_contract_from_local_input("Foo", path, "v0.8.26+commit.8a97fa7a")
+
+    assert contract["name"] == "Foo"
+    assert contract["compiler"] == "v0.8.26+commit.8a97fa7a"
+    assert contract["evm_version"] == "cancun"
+    assert contract.get("libraries") is None
+    assert contract.get("constructor_arguments") is None
+    assert "contracts/Foo.sol" in contract["solcInput"]["sources"]
+    # outputSelection is forced so bytecode parsing always has what it needs
+    output_selection = contract["solcInput"]["settings"]["outputSelection"]
+    assert "evm.deployedBytecode" in output_selection["*"]["*"]
+
+
+def test_build_contract_from_local_input_keeps_libraries(tmp_path):
+    lib_address = "0x" + "11" * 20
+    payload = {
+        "language": "Solidity",
+        "sources": {"contracts/Lib.sol": {"content": "library Lib {}"}},
+        "settings": {"libraries": {"contracts/Lib.sol": {"Lib": lib_address}}},
+    }
+    path = tmp_path / "input.json"
+    path.write_text(json.dumps(payload))
+
+    contract = build_contract_from_local_input("Lib", str(path), "v0.8.26")
+    assert contract["libraries"] == {"contracts/Lib.sol": {"Lib": lib_address}}
+
+
+def test_build_contract_from_local_input_errors(tmp_path):
+    missing_sources = tmp_path / "bad.json"
+    missing_sources.write_text(json.dumps({"language": "Solidity"}))
+    not_json = tmp_path / "not.json"
+    not_json.write_text("{nope")
+    for path in (missing_sources, not_json, tmp_path / "does_not_exist.json"):
+        with pytest.raises(ExplorerError):
+            build_contract_from_local_input("Foo", str(path), "v0.8.26")
+
+
+def test_get_local_inputs_resolves_relative_to_config(tmp_path):
+    config = {
+        "local_compilation": {
+            "compiler": "v0.8.26",
+            "inputs": {"0xAbC0000000000000000000000000000000000001": "inputs/Foo.json"},
+        }
+    }
+    config_path = str(tmp_path / "cfg.yaml")
+    resolved = _get_local_inputs(config, config_path)
+
+    # address lowercased, path made absolute against the config directory
+    expected = str(tmp_path / "inputs" / "Foo.json")
+    assert resolved == {"0xabc0000000000000000000000000000000000001": expected}
+
+
+def test_get_local_inputs_keeps_absolute_paths(tmp_path):
+    absolute = str(tmp_path / "elsewhere" / "Foo.json")
+    config = {
+        "local_compilation": {
+            "compiler": "v0.8.26",
+            "inputs": {"0xAbC0000000000000000000000000000000000001": absolute},
+        }
+    }
+    resolved = _get_local_inputs(config, str(tmp_path / "cfg.yaml"))
+    assert resolved == {"0xabc0000000000000000000000000000000000001": absolute}
+
+
+def test_get_local_inputs_empty_when_absent(tmp_path):
+    assert _get_local_inputs({}, str(tmp_path / "cfg.yaml")) == {}
+    assert _get_local_inputs({"local_compilation": {}}, str(tmp_path / "c.yaml")) == {}

--- a/tests/test_local_compilation.py
+++ b/tests/test_local_compilation.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from diffyscan.diffyscan import _get_local_inputs
+from diffyscan.utils.common import load_config
 from diffyscan.utils.custom_exceptions import ExplorerError
 from diffyscan.utils.explorer import build_contract_from_local_input
 
@@ -82,6 +83,34 @@ def test_get_local_inputs_keeps_absolute_paths(tmp_path):
     }
     resolved = _get_local_inputs(config, str(tmp_path / "cfg.yaml"))
     assert resolved == {"0xabc0000000000000000000000000000000000001": absolute}
+
+
+def test_build_contract_from_local_input_null_settings(tmp_path):
+    payload = {
+        "language": "Solidity",
+        "sources": {"contracts/Foo.sol": {"content": "contract Foo {}"}},
+        "settings": None,
+    }
+    path = tmp_path / "input.json"
+    path.write_text(json.dumps(payload))
+
+    contract = build_contract_from_local_input("Foo", str(path), "v0.8.26")
+    output_selection = contract["solcInput"]["settings"]["outputSelection"]
+    assert "evm.deployedBytecode" in output_selection["*"]["*"]
+
+
+def test_yaml_unquoted_local_input_address_rejected(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        "contracts:\n"
+        '  "0x0000000000000000000000000000000000000001": Foo\n'
+        "local_compilation:\n"
+        "  compiler: v0.8.26\n"
+        "  inputs:\n"
+        "    0x0000000000000000000000000000000000000001: inputs/foo.json\n"
+    )
+    with pytest.raises(ValueError, match="local_compilation.inputs"):
+        load_config(str(path))
 
 
 def test_get_local_inputs_empty_when_absent(tmp_path):


### PR DESCRIPTION
Contracts **without explorer-verified** source can now **be checked at the bytecode level**: local_compilation.inputs maps an address to a local solc standard-JSON input (source manifest + compiler settings), and local_compilation.compiler pins the solc build. Source contents are still fetched from the pinned GitHub commit, and the source diff is skipped for these addresses since there is nothing explorer-side to diff against.

## Relation to `feat/local-compilation-mode`

This PR implements the same feature as in `feat/local-compilation-mode` and **keeps its config
schema verbatim** (`local_compilation: {compiler, inputs}`), so any config written
for either branch works with both. We propose landing this implementation because:

1. **Rebased on current `main`.** The earlier branch forked ~82 commits back,
   before the `allowed_diffs` machinery and related `process_config` refactors,
   and no longer applies cleanly. This one is written against today's `main` and
   composes with allowlists, caching, and the summary/suggestion output.

2. **Local contracts reuse the explorer normalization path.** The payload is built
   via the existing `_build_contract_payload`/`_attach_contract_metadata` helpers
   instead of by hand, so EVM-version normalization and library re-keying to the
   definition file (required for correct solc linking) apply to local inputs
   exactly as they do to explorer bundles.

3. **More guardrails.** All-local configs need no explorer hostname/chain-id/token
   at all; unknown addresses in `local_compilation.inputs` are flagged; a config
   whose local contracts would get zero verification (bytecode comparison off)
   warns; the skipped source diff is logged per contract rather than silent;
   malformed/empty solc inputs are rejected with clear errors.

4. **Docs and tests included.** README section (schema + why a full-bytecode match
   incl. the CBOR metadata tail is sound evidence for guessed settings), CLAUDE.md
   schema note, and tests covering error paths (malformed JSON, empty sources,
   absolute/relative input paths).