### PR TITLE
docs: fill reference and explanation gaps

### DIFF
--- a/docs/bytecode-comparison.md
+++ b/docs/bytecode-comparison.md
@@ -30,10 +30,12 @@ It verifies the rest independently: file contents against the GitHub commit,
 compiled runtime bytecode against `eth_getCode`, and constructor-set immutable
 values through simulation against on-chain state.
 
-Wrong explorer metadata surfaces as a source or bytecode mismatch rather than
-a silent pass, because the deployed bytecode is the reference. Add manual
-overrides only when that metadata is missing or does not describe the
-deployment being checked.
+Trusted metadata that changes the compiled or simulated runtime bytecode
+surfaces as a mismatch, because the deployed bytecode is the reference.
+Metadata without runtime effect goes unchecked: constructor calldata, for
+example, is never read when the compiled runtime bytecode already matches the
+chain. Add manual overrides only when that metadata is missing or does not
+describe the deployment being checked.
 
 ## Manual overrides
 

--- a/docs/bytecode-comparison.md
+++ b/docs/bytecode-comparison.md
@@ -16,9 +16,14 @@ For each configured contract, Diffyscan:
 
 ## Trust model
 
-Contract sources always come from the pinned GitHub commit. The explorer
-submission only shapes how they are compiled and simulated. Diffyscan takes
-these explorer inputs on trust:
+Diffyscan relies on two trust anchors that it does not verify:
+
+- the pinned GitHub commit supplies the expected contract sources;
+- the configured RPC supplies deployed runtime bytecode through `eth_getCode`
+  and chain state for deployment simulation through `eth_call`.
+
+The explorer submission shapes how the GitHub sources are compiled and
+simulated. Diffyscan takes these explorer inputs on trust:
 
 - compiler version and settings, including optimizer configuration;
 - EVM version;
@@ -26,9 +31,15 @@ these explorer inputs on trust:
 - linked-library addresses;
 - the set of source file paths in the verified submission.
 
-It verifies the rest independently: file contents against the GitHub commit,
-compiled runtime bytecode against `eth_getCode`, and constructor-set immutable
-values through simulation against on-chain state.
+Within these trust boundaries, Diffyscan compares explorer file contents with
+the pinned GitHub commit, compiled runtime bytecode with the value returned by
+the configured RPC, and constructor-set immutable values through simulation
+against that RPC's state.
+
+Diffyscan logs the RPC chain ID but does not compare it with
+`explorer_chain_id`. Configure the explorer and RPC for the same chain. A wrong
+or compromised RPC controls both the deployed bytecode reference and the state
+used for simulation.
 
 Trusted metadata that changes the compiled or simulated runtime bytecode
 surfaces as a mismatch, because the deployed bytecode is the reference.

--- a/docs/bytecode-comparison.md
+++ b/docs/bytecode-comparison.md
@@ -14,9 +14,26 @@ For each configured contract, Diffyscan:
    prevent a direct match;
 6. evaluates any `allowed_diffs` rules and reports uncovered differences.
 
-Diffyscan reuses explorer-provided constructor calldata, linked-library
-addresses, and EVM version. Add manual overrides only when that metadata is
-missing or does not describe the deployment being checked.
+## Trust model
+
+Contract sources always come from the pinned GitHub commit. The explorer
+submission only shapes how they are compiled and simulated. Diffyscan takes
+these explorer inputs on trust:
+
+- compiler version and settings, including optimizer configuration;
+- EVM version;
+- constructor calldata;
+- linked-library addresses;
+- the set of source file paths in the verified submission.
+
+It verifies the rest independently: file contents against the GitHub commit,
+compiled runtime bytecode against `eth_getCode`, and constructor-set immutable
+values through simulation against on-chain state.
+
+Wrong explorer metadata surfaces as a source or bytecode mismatch rather than
+a silent pass, because the deployed bytecode is the reference. Add manual
+overrides only when that metadata is missing or does not describe the
+deployment being checked.
 
 ## Manual overrides
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,11 @@ The Etherscan path reads the token from the variable named by
 `explorer_token_env_var`. With `explorer_chain_id` set, requests go to the
 multi-chain `/v2/api` endpoint; without it, to the legacy `/api` endpoint.
 
+The Token column describes what the request sends. Diffyscan resolves a token
+before selecting the explorer, so the variable named by
+`explorer_token_env_var` (or the `ETHERSCAN_EXPLORER_TOKEN` fallback) must
+hold a value even for explorers that do not use it.
+
 The Blockscout domains are matched literally. A Blockscout instance on any
 other domain falls into the Etherscan path and fails with a response-format
 error. Extend `_get_explorer_fetcher` in

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,28 @@ The optional `network`, `audit_url`, and `metadata` fields carry information for
 people and external tooling. Diffyscan preserves them while loading a config but
 does not use them during verification.
 
+## Supported explorers
+
+`explorer_hostname` selects the explorer API by pattern:
+
+| Hostname | API | Token |
+| --- | --- | --- |
+| Starts with `zksync` | zkSync contract verification API | Not used |
+| Ends with `mantle.xyz` | Mantle Etherscan-style API | Not used |
+| Ends with `lineascan.build` | Etherscan-style API | Not used |
+| Ends with `blockscout.com`, `mode.network`, `swellnetwork.io`, `lisk.com`, `inkonchain.com`, `routescan.io`, or `monadvision.com` | Blockscout API v2 | Not used |
+| Anything else | Etherscan API | Required |
+
+The Etherscan path reads the token from the variable named by
+`explorer_token_env_var`. With `explorer_chain_id` set, requests go to the
+multi-chain `/v2/api` endpoint; without it, to the legacy `/api` endpoint.
+
+The Blockscout domains are matched literally. A Blockscout instance on any
+other domain falls into the Etherscan path and fails with a response-format
+error. Extend `_get_explorer_fetcher` in
+[`diffyscan/utils/explorer.py`](../diffyscan/utils/explorer.py) to add a
+domain.
+
 ## GitHub sources
 
 `github_repo` pins the source being verified:
@@ -119,6 +141,10 @@ Optional:
   request. The default is a browser-like string ending in
   `diffyscan/<version>`: Cloudflare in front of some Blockscout instances
   rejects non-browser User-Agents.
+
+Names such as `L1_EXPLORER_API_HOSTNAME` and `ETHEREUM_RPC_URL` in
+[`.env.example`](../.env.example) carry no built-in meaning. Configs reference
+them through `explorer_hostname_env_var` and `rpc_url_env_var`.
 
 Keep secrets and RPC credentials out of the config file.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,8 +99,12 @@ before selecting the explorer, so the variable named by
 hold a value even for explorers that do not use it.
 
 The Blockscout domains are matched literally. A Blockscout instance on any
-other domain falls into the Etherscan path and fails with a response-format
-error. Extend `_get_explorer_fetcher` in
+other domain falls into the Etherscan path instead of the Blockscout v2 path.
+Depending on the host and `explorer_chain_id`, the request may fail or an
+Etherscan-compatible endpoint may return only the primary source under the
+contract name while omitting additional sources. The latter case fails later
+with missing-GitHub-source or compilation errors. Extend
+`_get_explorer_fetcher` in
 [`diffyscan/utils/explorer.py`](../diffyscan/utils/explorer.py) to add a
 domain.
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -106,8 +106,11 @@ rm -rf .diffyscan_cache/
 
 ## Accept an expected difference
 
-A run that exits with status 1 prints every uncovered difference in the final
-summary, each with a suggested `allowed_diffs` entry.
+A run that fails because of uncovered source or bytecode differences prints
+each one in the final summary with a suggested `allowed_diffs` entry.
+Operational failures (compilation, calldata, RPC, deployment simulation) and
+contract filters that match nothing also exit with status 1 but produce no
+suggestion. Fix the cause instead of adding a rule.
 
 1. Open the HTML diff under `digest/<timestamp>/diffs/<contract-address>/` for
    source differences, or read the reported byte offsets for bytecode

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -104,6 +104,26 @@ Remove both caches when you need fresh remote inputs:
 rm -rf .diffyscan_cache/
 ```
 
+## Accept an expected difference
+
+A run that exits with status 1 prints every uncovered difference in the final
+summary, each with a suggested `allowed_diffs` entry.
+
+1. Open the HTML diff under `digest/<timestamp>/diffs/<contract-address>/` for
+   source differences, or read the reported byte offsets for bytecode
+   differences.
+2. Confirm the difference is expected. A difference you cannot explain is a
+   finding, not a rule to add.
+3. Copy the suggested entry from the summary into the config and replace the
+   placeholder `reason` with the actual justification.
+4. Rerun the config. The run passes once every difference is covered.
+
+Prefer the narrowest facet the suggestion offers: exact `immutables` or
+`line_ranges` over `byte_ranges` or `files`, and never `any: true` for a
+difference that can be scoped. See
+[Bytecode Comparison](bytecode-comparison.md#allowed-differences) for the
+facet reference.
+
 ## Run in CI
 
 Use `--yes` to disable confirmation prompts and `--quiet` to hide informational


### PR DESCRIPTION
Fills three documentation gaps found while reviewing the docs against [Diátaxis](https://diataxis.fr/):

- **Supported explorers** (configuration.md): documents the hostname-based fetcher dispatch — zkSync, Mantle, Lineascan, the literal Blockscout domain list, and the Etherscan-compatible default with its token requirement and v2 `chainid` behavior. Previously a Blockscout instance on an unlisted domain fell into the Etherscan path with no documented explanation. Also clarifies that env var names in `.env.example` carry no built-in meaning.
- **Accept an expected difference** (how-to.md): task-oriented walkthrough from a failing run to a scoped `allowed_diffs` rule, linking to the facet reference.
- **Trust model** (bytecode-comparison.md): expands the two-line note on trusted explorer inputs into an explicit list of what is trusted vs. verified independently, and why wrong metadata fails the check instead of passing it.