### PR TITLE
feat: add mainnet DelegationFactory config and CI regression entry

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -45,6 +45,8 @@ jobs:
             network: mainnet
           - config: config_samples/ethereum/mainnet/srv3/srv3_upgrade_template_config.yaml
             network: mainnet
+          - config: config_samples/ethereum/mainnet/execution-delegation/delegation_factory_config.yaml
+            network: mainnet
           - config: config_samples/ethereum/hoodi/vaults/hoodi_vaults_testnet_config.json
             network: hoodi
           - config: config_samples/ethereum/hoodi/vaults/hoodi_vaults_easy_track_config.json

--- a/config_samples/ethereum/mainnet/execution-delegation/delegation_factory_config.yaml
+++ b/config_samples/ethereum/mainnet/execution-delegation/delegation_factory_config.yaml
@@ -1,0 +1,25 @@
+contracts:
+  "0xD990770eB2B4b6062EDdB06892fF179C693b46e6": DelegationFactory
+
+explorer_hostname: api.etherscan.io
+explorer_token_env_var: ETHERSCAN_EXPLORER_TOKEN
+explorer_chain_id: 1
+
+github_repo:
+  url: https://github.com/lidofinance/execution-delegation-framework/
+  # https://github.com/lidofinance/execution-delegation-framework/blob/main/artifacts/mainnet/deploy-mainnet.json
+  commit: 557299104ad3eb1a74198933bd016328c490e276
+  relative_root: ""
+
+dependencies:
+  # Explorer-verified source paths keep the Foundry "node_modules/" prefix
+  "node_modules/@openzeppelin/contracts":
+    url: https://github.com/OpenZeppelin/openzeppelin-contracts
+    commit: c64a1edb67b6e3f4a15cca8909c9482ad33a02b0 # v5.4.0
+    relative_root: contracts
+
+fail_on_bytecode_comparison_error: true
+
+bytecode_comparison:
+  constructor_calldata: {}
+  constructor_args: {}


### PR DESCRIPTION
## Summary

Adds a diffyscan config for the DelegationFactory contract deployed to Ethereum mainnet (lidofinance/execution-delegation-framework#25) and includes it in the CI regression matrix. Delegator contract configs will be added later.

## Changes

- config_samples/ethereum/mainnet/execution-delegation/delegation_factory_config.yaml - new config for DelegationFactory at 0xD990770eB2B4b6062EDdB06892fF179C693b46e6, pinned to the deploy commit 5572991 from artifacts/mainnet/deploy-mainnet.json; the only dependency is @openzeppelin/contracts v5.4.0; the factory has no constructor args
- .github/workflows/regression.yml - new matrix entry for this config with network: mainnet

## Testing

- uv run pytest -q - 374 passed (test_configs.py validates all config samples)
- uv run mypy and uv run pre-commit run --all-files - clean
- Full diffyscan run happens in CI via the new regression matrix entry

## Related Issues

STC-890