### PR TITLE
feat: add --json flag for machine-readable output

### DIFF
--- a/.claude/skills/debug-diff/SKILL.md
+++ b/.claude/skills/debug-diff/SKILL.md
@@ -86,7 +86,7 @@ uv run diffyscan <config-path> --yes --cache-explorer --cache-github
 - `--cache-explorer` (`-E`) reuses cached explorer responses from `.diffyscan_cache/`
 - `--cache-github` (`-G`) reuses cached GitHub file fetches
 - `--support-brownie` enables recursive retrieval for brownie-verified contracts with flattened import paths
-- `--json` (`-J`) prints one JSON report to stdout instead of logs: per-contract `source`/`bytecode` status, diff hunks, `uncovered` bytecode ranges, error text, and ready `suggested_rule` entries for `allowed_diffs`. Prefer it when re-running to inspect results; check `status` (a skipped contract makes it `error` even with exit code 0)
+- `--json` (`-J`) prints one JSON report to stdout instead of logs: per-contract `source`/`bytecode` status, diff hunks, `uncovered` bytecode ranges, error text, and ready `suggested_rule` entries for `allowed_diffs`. Prefer it when re-running to inspect results; the format is specified in `docs/json-output.md`. Check `status`, not only the exit code (a skipped contract makes it `error` even with exit code 0)
 
 To accept known diffs, use config `allowed_diffs` rules. (The former `--allow-source-diff` / `--allow-bytecode-diff` CLI flags have been removed; they were blanket `any: true` shorthands.) When a diff is uncovered, diffyscan prints a ready-to-paste `allowed_diffs` snippet in the final summary — paste it into the config and replace the placeholder `reason`, tightening `any: true` to a granular facet (`immutables`, `byte_ranges`, `cbor_metadata`, `line_ranges`, `files`) wherever possible. See the "Granular allowlists" section of the README.
 

--- a/.claude/skills/debug-diff/SKILL.md
+++ b/.claude/skills/debug-diff/SKILL.md
@@ -86,6 +86,7 @@ uv run diffyscan <config-path> --yes --cache-explorer --cache-github
 - `--cache-explorer` (`-E`) reuses cached explorer responses from `.diffyscan_cache/`
 - `--cache-github` (`-G`) reuses cached GitHub file fetches
 - `--support-brownie` enables recursive retrieval for brownie-verified contracts with flattened import paths
+- `--json` (`-J`) prints one JSON report to stdout instead of logs: per-contract `source`/`bytecode` status, diff hunks, `uncovered` bytecode ranges, error text, and ready `suggested_rule` entries for `allowed_diffs`. Prefer it when re-running to inspect results; check `status` (a skipped contract makes it `error` even with exit code 0)
 
 To accept known diffs, use config `allowed_diffs` rules. (The former `--allow-source-diff` / `--allow-bytecode-diff` CLI flags have been removed; they were blanket `any: true` shorthands.) When a diff is uncovered, diffyscan prints a ready-to-paste `allowed_diffs` snippet in the final summary — paste it into the config and replace the placeholder `reason`, tightening `any: true` to a granular facet (`immutables`, `byte_ranges`, `cbor_metadata`, `line_ranges`, `files`) wherever possible. See the "Granular allowlists" section of the README.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ uv run pytest tests/test_config_loading.py::test_name -q
 # Run the CLI
 uv run diffyscan configs/<project>/<mainnet|testnet>/<config>.yaml
 
-# Machine-readable run (one JSON document on stdout, logs only in digest/<ts>/logs.txt)
+# Machine-readable run (one JSON document on stdout, logs only in digest/<ts>/logs.txt; format: docs/json-output.md)
 uv run diffyscan configs/<project>/<mainnet|testnet>/<config>.yaml --json -E -G
 
 # Format code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ uv run pytest tests/test_config_loading.py::test_name -q
 # Run the CLI
 uv run diffyscan configs/<project>/<mainnet|testnet>/<config>.yaml
 
+# Machine-readable run (one JSON document on stdout, logs only in digest/<ts>/logs.txt)
+uv run diffyscan configs/<project>/<mainnet|testnet>/<config>.yaml --json -E -G
+
 # Format code
 uv run black diffyscan/ tests/
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <a href="https://github.com/lidofinance/diffyscan/blob/main/docs/how-to.md">How-To Guides</a> ·
   <a href="https://github.com/lidofinance/diffyscan/blob/main/docs/configuration.md">Configuration Reference</a> ·
   <a href="https://github.com/lidofinance/diffyscan/blob/main/docs/cli.md">CLI Reference</a> ·
+  <a href="https://github.com/lidofinance/diffyscan/blob/main/docs/json-output.md">JSON Output</a> ·
   <a href="https://github.com/lidofinance/diffyscan/blob/main/docs/bytecode-comparison.md">Bytecode Comparison</a>
 </p>
 

--- a/diffyscan/diffyscan.py
+++ b/diffyscan/diffyscan.py
@@ -610,6 +610,13 @@ def process_config(
     config: dict = load_config(path)  # type: ignore[assignment]
     effective_allowed_diffs = build_effective_allowed_diffs(config)
 
+    enable_source_comparison = config.get("source_comparison", True)
+    if not enable_source_comparison and not enable_binary_comparison:
+        raise ValueError(
+            f"Both source and bytecode comparisons are disabled in {path}. "
+            "Enable source_comparison or remove --skip-binary-comparison."
+        )
+
     explorer_token = _load_explorer_token(config)
     github_api_token = load_env("GITHUB_API_TOKEN", masked=True, required=True)
 
@@ -617,7 +624,6 @@ def process_config(
     if enable_binary_comparison:
         remote_rpc_url = _setup_binary_comparison(config)
 
-    enable_source_comparison = config.get("source_comparison", True)
     if not enable_source_comparison:
         logger.warn(
             f'Source code comparison is disabled in {path}. To enable, set "source_comparison": true in the config'
@@ -882,12 +888,20 @@ def _collect_config_paths(path: str | None) -> list[str]:
     if os.path.isfile(path):
         return [path]
     if os.path.isdir(path):
-        return [
+        config_paths = [
             os.path.join(path, filename)
             for filename in sorted(os.listdir(path))
             if os.path.isfile(os.path.join(path, filename))
             and filename.lower().endswith(supported_extensions)
         ]
+        if not config_paths:
+            error_msg = (
+                f"No config files found directly in {path}. Discovery is not "
+                "recursive; pass a nested directory or a config file instead."
+            )
+            logger.error(error_msg)
+            raise FileNotFoundError(error_msg)
+        return config_paths
     error_msg = f"Specified config path {path} not found"
     logger.error(error_msg)
     raise FileNotFoundError(error_msg)
@@ -1056,6 +1070,11 @@ def main() -> None:
                 break
             if result["error"] is not None:
                 raise result["error"]
+    except KeyboardInterrupt:
+        # Ctrl+C outside process_config (e.g. while loading a config)
+        if not args.json:
+            raise
+        error = "KeyboardInterrupt: run interrupted by user"
     except Exception as exc:
         # In JSON mode the report must still reach stdout; keep the traceback on stderr.
         if not args.json:
@@ -1063,24 +1082,25 @@ def main() -> None:
         traceback.print_exc()
         error = f"{type(exc).__name__}: {exc}"
 
-    # A contract filter that matches nothing across all configs is a usage error
-    filter_unmatched = (
-        error is None
-        and bool(args.contract_filter)
-        and sum(r["matched_count"] for r in all_results) == 0
+    # A run that checked no contracts must never read as a verified run
+    nothing_checked = (
+        error is None and sum(r["matched_count"] for r in all_results) == 0
     )
-    if filter_unmatched:
-        logger.error(
-            "No contracts matched the --contract filter",
-            ", ".join(args.contract_filter),
-        )
+    if nothing_checked:
+        if args.contract_filter:
+            logger.error(
+                "No contracts matched the --contract filter",
+                ", ".join(args.contract_filter),
+            )
+        else:
+            logger.error("No contracts to check in the given configs")
         if not args.json:
             sys.exit(1)
 
     execution_time = time.time() - START_TIME
     enable_source_comparison = any(result["source_stats"] for result in all_results)
 
-    if error is None and not filter_unmatched:
+    if error is None and not nothing_checked:
         print_final_summary(
             all_results, enable_source_comparison, enable_binary_comparison
         )
@@ -1099,7 +1119,7 @@ def main() -> None:
     logger.okay(f"Done in {round(execution_time, 3)}s ✨" + " " * 100)
 
     exit_code = 0
-    if error is not None or filter_unmatched:
+    if error is not None or nothing_checked:
         exit_code = 1
     elif source_failures + bytecode_failures > 0:
         logger.error(

--- a/diffyscan/diffyscan.py
+++ b/diffyscan/diffyscan.py
@@ -25,7 +25,7 @@ from .utils.allowed_diffs import (
 from .utils.binary_verifier import analyze_bytecode_diff, log_bytecode_diff_analysis
 from .utils.calldata import get_calldata
 from .utils.common import load_config, load_env
-from .utils.constants import DIFFS_DIR, START_TIME
+from .utils.constants import DIFFS_DIR, LOGS_PATH, START_TIME
 from .utils.custom_exceptions import (
     BaseCustomException,
     CalldataError,
@@ -127,6 +127,8 @@ def _bytecode_result(
     matched_rule: dict | None = None,
     matched_facets: list | None = None,
     suggestion_entry: dict | None = None,
+    uncovered: list[str] | None = None,
+    error: str | None = None,
 ) -> dict:
     return {
         "contract_address": contract_address,
@@ -137,6 +139,8 @@ def _bytecode_result(
         "matched_rule": matched_rule,
         "matched_facets": matched_facets or [],
         "suggestion_entry": suggestion_entry,
+        "uncovered": uncovered or [],
+        "error": error,
     }
 
 
@@ -298,6 +302,7 @@ def run_bytecode_diff(
     )
 
     suggestion_entry = None
+    uncovered: list[str] = []
     if evaluation["status"] == "allowed":
         _log_allowed_diff("bytecode", address_name, evaluation)
     else:
@@ -305,6 +310,7 @@ def run_bytecode_diff(
         log_bytecode_diff_analysis(best_analysis)
         _log_uncovered_bytecode_diff(best_analysis)
         suggestion_entry = build_bytecode_suggestion_entry(best_analysis)
+        uncovered = summarize_bytecode_uncovered(best_analysis)
 
     return _bytecode_result(
         contract_address_from_config,
@@ -314,6 +320,7 @@ def run_bytecode_diff(
         matched_rule=evaluation["matched_rule"],
         matched_facets=evaluation["matched_facets"],
         suggestion_entry=suggestion_entry,
+        uncovered=uncovered,
     )
 
 
@@ -618,6 +625,7 @@ def process_config(
 
     source_stats = []
     bytecode_stats = []
+    contract_errors = []
     matched_count = 0
 
     try:
@@ -722,17 +730,26 @@ def process_config(
                                     contract_name,
                                     status="failed",
                                     match=False,
+                                    error=str(exc),
                                 )
                             )
             except BaseCustomException as custom_exc:
                 ExceptionHandler.raise_exception_or_log(custom_exc)
                 traceback.print_exc()
+                contract_errors.append(
+                    {
+                        "contract_address": contract_address,
+                        "contract_name": contract_name,
+                        "error": str(custom_exc),
+                    }
+                )
     except KeyboardInterrupt:
         logger.info("Keyboard interrupt by user")
 
     return {
         "source_stats": source_stats,
         "bytecode_stats": bytecode_stats,
+        "contract_errors": contract_errors,
         "config_path": path,
         "matched_count": matched_count,
     }
@@ -794,6 +811,12 @@ def parse_arguments() -> argparse.Namespace:
         action="store_true",
     )
     parser.add_argument(
+        "--json",
+        "-J",
+        help="Print a single JSON report to stdout instead of human-readable logs (implies --yes). Logs are still written to digest/<timestamp>/logs.txt.",
+        action="store_true",
+    )
+    parser.add_argument(
         "--contract",
         "-C",
         dest="contract_filter",
@@ -827,26 +850,10 @@ def print_final_summary(
     logger.info("=" * 80)
 
 
-def main() -> None:
-    load_dotenv()
-    args = parse_arguments()
-    if args.quiet:
-        logger.set_level("okay")
-    else:
-        logger.set_level(args.log_level)
-
-    if args.version:
-        print(f"Diffyscan {__version__}")
-        return
-
-    logger.info("Welcome to Diffyscan!")
-    logger.divider()
-
-    enable_binary_comparison = not args.skip_binary_comparison
-    config_paths = []
+def _collect_config_paths(path: str | None) -> list[str]:
     supported_extensions = (".json", ".yaml", ".yml")
 
-    if args.path is None:
+    if path is None:
         config_path = next(
             (
                 candidate
@@ -862,46 +869,190 @@ def main() -> None:
             )
             logger.error(error_msg)
             raise FileNotFoundError(error_msg)
-        config_paths.append(config_path)
-    elif os.path.isfile(args.path):
-        config_paths.append(args.path)
-    elif os.path.isdir(args.path):
-        for filename in sorted(os.listdir(args.path)):
-            full_path = os.path.join(args.path, filename)
-            if os.path.isfile(full_path) and filename.lower().endswith(
-                supported_extensions
-            ):
-                config_paths.append(full_path)
-    else:
-        error_msg = f"Specified config path {args.path} not found"
-        logger.error(error_msg)
-        raise FileNotFoundError(error_msg)
+        return [config_path]
+    if os.path.isfile(path):
+        return [path]
+    if os.path.isdir(path):
+        return [
+            os.path.join(path, filename)
+            for filename in sorted(os.listdir(path))
+            if os.path.isfile(os.path.join(path, filename))
+            and filename.lower().endswith(supported_extensions)
+        ]
+    error_msg = f"Specified config path {path} not found"
+    logger.error(error_msg)
+    raise FileNotFoundError(error_msg)
 
-    all_results = []
-    for config_path in config_paths:
-        result = process_config(
-            config_path,
-            args.support_brownie,
-            enable_binary_comparison,
-            args.cache_explorer,
-            args.cache_github,
-            args.yes,
-            args.contract_filter,
+
+def _json_counts(all_results: list[dict], key: str) -> dict:
+    stats = [stat for result in all_results for stat in result[key]]
+    return {
+        "total": len(stats),
+        "exact": sum(stat["status"] == "exact" for stat in stats),
+        "allowed": sum(stat["status"] == "allowed" for stat in stats),
+        "failed": sum(stat["status"] == "failed" for stat in stats),
+    }
+
+
+def _json_source_entry(stat: dict) -> dict:
+    return {
+        "status": stat["status"],
+        "files_count": stat["files_count"],
+        "files_found": stat["files_found"],
+        "identical_files": stat["identical_files"],
+        "files_with_diffs": stat["files_with_diffs"],
+        "matched_rule": stat["matched_rule"],
+        "matched_facets": stat["matched_facets"],
+        "diff_files": [
+            {
+                "path": file_result["path"],
+                "file_found": file_result["file_found"],
+                "diff_report": file_result["diff_report_filename"],
+                "hunks": file_result["hunks"],
+            }
+            for file_result in stat["files"]
+            if file_result["hunks"] or not file_result["file_found"]
+        ],
+        "suggested_rule": stat["suggestion_entry"],
+    }
+
+
+def _json_bytecode_entry(stat: dict) -> dict:
+    return {
+        "status": stat["status"],
+        "match": stat["match"],
+        "matched_rule": stat["matched_rule"],
+        "matched_facets": stat["matched_facets"],
+        "uncovered": stat["uncovered"],
+        "error": stat["error"],
+        "suggested_rule": stat["suggestion_entry"],
+    }
+
+
+def build_json_report(
+    all_results: list[dict],
+    *,
+    exit_code: int,
+    error: str | None,
+    duration_seconds: float,
+) -> dict:
+    configs = []
+    for result in all_results:
+        contracts: dict[str, dict] = {}
+        for kind, key, to_entry in (
+            ("source", "source_stats", _json_source_entry),
+            ("bytecode", "bytecode_stats", _json_bytecode_entry),
+        ):
+            for stat in result[key]:
+                contract = contracts.setdefault(
+                    stat["contract_address"],
+                    {
+                        "address": stat["contract_address"],
+                        "name": stat["contract_name"],
+                        "source": None,
+                        "bytecode": None,
+                    },
+                )
+                contract[kind] = to_entry(stat)
+        for failure in result["contract_errors"]:
+            contract = contracts.setdefault(
+                failure["contract_address"],
+                {
+                    "address": failure["contract_address"],
+                    "name": failure["contract_name"],
+                    "source": None,
+                    "bytecode": None,
+                },
+            )
+            contract["error"] = failure["error"]
+        configs.append(
+            {"path": result["config_path"], "contracts": list(contracts.values())}
         )
-        all_results.append(result)
+
+    contract_error_count = sum(len(r["contract_errors"]) for r in all_results)
+    if error is not None or contract_error_count:
+        status = "error"
+    elif exit_code:
+        status = "failed"
+    else:
+        status = "passed"
+
+    return {
+        "diffyscan_version": __version__,
+        "status": status,
+        "exit_code": exit_code,
+        "error": error,
+        "duration_seconds": round(duration_seconds, 3),
+        "log_file": LOGS_PATH,
+        "summary": {
+            "source": _json_counts(all_results, "source_stats"),
+            "bytecode": _json_counts(all_results, "bytecode_stats"),
+            "contract_errors": contract_error_count,
+        },
+        "configs": configs,
+    }
+
+
+def main() -> None:
+    load_dotenv()
+    args = parse_arguments()
+    if args.quiet:
+        logger.set_level("okay")
+    else:
+        logger.set_level(args.log_level)
+    if args.json:
+        logger.stdout_enabled = False
+
+    if args.version:
+        print(f"Diffyscan {__version__}")
+        return
+
+    logger.info("Welcome to Diffyscan!")
+    logger.divider()
+
+    enable_binary_comparison = not args.skip_binary_comparison
+    all_results: list[dict] = []
+    error: str | None = None
+
+    try:
+        for config_path in _collect_config_paths(args.path):
+            all_results.append(
+                process_config(
+                    config_path,
+                    args.support_brownie,
+                    enable_binary_comparison,
+                    args.cache_explorer,
+                    args.cache_github,
+                    args.yes or args.json,
+                    args.contract_filter,
+                )
+            )
+    except Exception as exc:
+        # In JSON mode the report must still reach stdout; keep the traceback on stderr.
+        if not args.json:
+            raise
+        traceback.print_exc()
+        error = f"{type(exc).__name__}: {exc}"
 
     # A contract filter that matches nothing across all configs is a usage error
-    if args.contract_filter and sum(r["matched_count"] for r in all_results) == 0:
-        logger.error(
-            "No contracts matched the --contract filter",
-            ", ".join(args.contract_filter),
-        )
-        sys.exit(1)
+    if (
+        error is None
+        and args.contract_filter
+        and sum(r["matched_count"] for r in all_results) == 0
+    ):
+        filter_label = ", ".join(args.contract_filter)
+        logger.error("No contracts matched the --contract filter", filter_label)
+        if not args.json:
+            sys.exit(1)
+        error = f"No contracts matched the --contract filter: {filter_label}"
 
     execution_time = time.time() - START_TIME
     enable_source_comparison = any(result["source_stats"] for result in all_results)
 
-    print_final_summary(all_results, enable_source_comparison, enable_binary_comparison)
+    if error is None:
+        print_final_summary(
+            all_results, enable_source_comparison, enable_binary_comparison
+        )
 
     source_failures = sum(
         stat["status"] == "failed"
@@ -916,14 +1067,26 @@ def main() -> None:
 
     logger.okay(f"Done in {round(execution_time, 3)}s ✨" + " " * 100)
 
-    if source_failures + bytecode_failures > 0:
+    exit_code = 0
+    if error is not None:
+        exit_code = 1
+    elif source_failures + bytecode_failures > 0:
         logger.error(
             "Exiting with non-zero code due to unallowed diffs",
             f"source={source_failures}, bytecode={bytecode_failures}",
         )
-        sys.exit(1)
+        exit_code = 1
 
-    sys.exit(0)
+    if args.json:
+        report = build_json_report(
+            all_results,
+            exit_code=exit_code,
+            error=error,
+            duration_seconds=execution_time,
+        )
+        print(json.dumps(report, indent=2, default=str))
+
+    sys.exit(exit_code)
 
 
 def is_standard_json_contract(source_files: dict) -> bool:

--- a/diffyscan/diffyscan.py
+++ b/diffyscan/diffyscan.py
@@ -813,7 +813,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--json",
         "-J",
-        help="Print a single JSON report to stdout instead of human-readable logs (implies --yes). Logs are still written to digest/<timestamp>/logs.txt.",
+        help="Print a single JSON report to stdout instead of human-readable logs (implies --yes). Logs are still written to digest/<timestamp>/logs.txt. Format: docs/json-output.md",
         action="store_true",
     )
     parser.add_argument(
@@ -884,8 +884,19 @@ def _collect_config_paths(path: str | None) -> list[str]:
     raise FileNotFoundError(error_msg)
 
 
-def _json_counts(all_results: list[dict], key: str) -> dict:
+def _compact(mapping: dict) -> dict:
+    """Drop keys whose value is None or an empty list so reports stay short."""
+    return {
+        key: value
+        for key, value in mapping.items()
+        if value is not None and value != []
+    }
+
+
+def _json_counts(all_results: list[dict], key: str) -> dict | None:
     stats = [stat for result in all_results for stat in result[key]]
+    if not stats:
+        return None
     return {
         "total": len(stats),
         "exact": sum(stat["status"] == "exact" for stat in stats),
@@ -894,39 +905,50 @@ def _json_counts(all_results: list[dict], key: str) -> dict:
     }
 
 
-def _json_source_entry(stat: dict) -> dict:
+def _json_rule_fields(stat: dict) -> dict:
+    rule = stat["matched_rule"] or {}
     return {
-        "status": stat["status"],
-        "files_count": stat["files_count"],
-        "files_found": stat["files_found"],
-        "identical_files": stat["identical_files"],
-        "files_with_diffs": stat["files_with_diffs"],
-        "matched_rule": stat["matched_rule"],
-        "matched_facets": stat["matched_facets"],
-        "diff_files": [
-            {
-                "path": file_result["path"],
-                "file_found": file_result["file_found"],
-                "diff_report": file_result["diff_report_filename"],
-                "hunks": file_result["hunks"],
-            }
-            for file_result in stat["files"]
-            if file_result["hunks"] or not file_result["file_found"]
-        ],
+        "facets": stat["matched_facets"],
+        "reason": rule.get("reason"),
         "suggested_rule": stat["suggestion_entry"],
     }
+
+
+def _json_source_entry(stat: dict) -> dict:
+    diffs = [
+        _compact(
+            {
+                "path": file_result["path"],
+                "missing": True if not file_result["file_found"] else None,
+                "report": file_result["diff_report_filename"],
+                "hunks": file_result["hunks"],
+            }
+        )
+        for file_result in stat["files"]
+        if file_result["hunks"] or not file_result["file_found"]
+    ]
+    missing = stat["files_count"] - stat["files_found"]
+    return _compact(
+        {
+            "status": stat["status"],
+            "files": stat["files_count"],
+            "missing": missing or None,
+            "with_diffs": stat["files_with_diffs"] or None,
+            "diffs": diffs,
+            **_json_rule_fields(stat),
+        }
+    )
 
 
 def _json_bytecode_entry(stat: dict) -> dict:
-    return {
-        "status": stat["status"],
-        "match": stat["match"],
-        "matched_rule": stat["matched_rule"],
-        "matched_facets": stat["matched_facets"],
-        "uncovered": stat["uncovered"],
-        "error": stat["error"],
-        "suggested_rule": stat["suggestion_entry"],
-    }
+    return _compact(
+        {
+            "status": stat["status"],
+            "uncovered": stat["uncovered"],
+            "error": stat["error"],
+            **_json_rule_fields(stat),
+        }
+    )
 
 
 def build_json_report(
@@ -936,38 +958,29 @@ def build_json_report(
     error: str | None,
     duration_seconds: float,
 ) -> dict:
-    configs = []
+    contracts: list[dict] = []
     for result in all_results:
-        contracts: dict[str, dict] = {}
-        for kind, key, to_entry in (
-            ("source", "source_stats", _json_source_entry),
-            ("bytecode", "bytecode_stats", _json_bytecode_entry),
-        ):
-            for stat in result[key]:
-                contract = contracts.setdefault(
-                    stat["contract_address"],
-                    {
-                        "address": stat["contract_address"],
-                        "name": stat["contract_name"],
-                        "source": None,
-                        "bytecode": None,
-                    },
-                )
-                contract[kind] = to_entry(stat)
-        for failure in result["contract_errors"]:
-            contract = contracts.setdefault(
-                failure["contract_address"],
-                {
-                    "address": failure["contract_address"],
-                    "name": failure["contract_name"],
-                    "source": None,
-                    "bytecode": None,
-                },
+        by_address: dict[str, dict] = {}
+
+        def entry(address: str, name: str) -> dict:
+            return by_address.setdefault(
+                address,
+                {"config": result["config_path"], "address": address, "name": name},
             )
-            contract["error"] = failure["error"]
-        configs.append(
-            {"path": result["config_path"], "contracts": list(contracts.values())}
-        )
+
+        for stat in result["source_stats"]:
+            entry(stat["contract_address"], stat["contract_name"])["source"] = (
+                _json_source_entry(stat)
+            )
+        for stat in result["bytecode_stats"]:
+            entry(stat["contract_address"], stat["contract_name"])["bytecode"] = (
+                _json_bytecode_entry(stat)
+            )
+        for failure in result["contract_errors"]:
+            entry(failure["contract_address"], failure["contract_name"])["error"] = (
+                failure["error"]
+            )
+        contracts.extend(by_address.values())
 
     contract_error_count = sum(len(r["contract_errors"]) for r in all_results)
     if error is not None or contract_error_count:
@@ -977,19 +990,21 @@ def build_json_report(
     else:
         status = "passed"
 
+    # "summary" and "contracts" are always present so consumers can rely on them.
     return {
-        "diffyscan_version": __version__,
         "status": status,
         "exit_code": exit_code,
-        "error": error,
+        **({"error": error} if error is not None else {}),
         "duration_seconds": round(duration_seconds, 3),
         "log_file": LOGS_PATH,
-        "summary": {
-            "source": _json_counts(all_results, "source_stats"),
-            "bytecode": _json_counts(all_results, "bytecode_stats"),
-            "contract_errors": contract_error_count,
-        },
-        "configs": configs,
+        "summary": _compact(
+            {
+                "source": _json_counts(all_results, "source_stats"),
+                "bytecode": _json_counts(all_results, "bytecode_stats"),
+                "contract_errors": contract_error_count or None,
+            }
+        ),
+        "contracts": contracts,
     }
 
 

--- a/diffyscan/diffyscan.py
+++ b/diffyscan/diffyscan.py
@@ -628,6 +628,7 @@ def process_config(
     contract_errors = []
     matched_count = 0
     interrupted = False
+    error: Exception | None = None
 
     try:
         if enable_binary_comparison:
@@ -747,6 +748,10 @@ def process_config(
     except KeyboardInterrupt:
         logger.info("Keyboard interrupt by user")
         interrupted = True
+    except Exception as exc:
+        # Hand the exception back with the results collected so far, so a fatal
+        # error on one contract does not discard verified diffs of the others.
+        error = exc
 
     return {
         "source_stats": source_stats,
@@ -755,6 +760,7 @@ def process_config(
         "config_path": path,
         "matched_count": matched_count,
         "interrupted": interrupted,
+        "error": error,
     }
 
 
@@ -1048,6 +1054,8 @@ def main() -> None:
                 # Partial results must never read as a verified run
                 error = "KeyboardInterrupt: run interrupted by user"
                 break
+            if result["error"] is not None:
+                raise result["error"]
     except Exception as exc:
         # In JSON mode the report must still reach stdout; keep the traceback on stderr.
         if not args.json:

--- a/diffyscan/diffyscan.py
+++ b/diffyscan/diffyscan.py
@@ -627,6 +627,7 @@ def process_config(
     bytecode_stats = []
     contract_errors = []
     matched_count = 0
+    interrupted = False
 
     try:
         if enable_binary_comparison:
@@ -745,6 +746,7 @@ def process_config(
                 )
     except KeyboardInterrupt:
         logger.info("Keyboard interrupt by user")
+        interrupted = True
 
     return {
         "source_stats": source_stats,
@@ -752,6 +754,7 @@ def process_config(
         "contract_errors": contract_errors,
         "config_path": path,
         "matched_count": matched_count,
+        "interrupted": interrupted,
     }
 
 
@@ -1031,17 +1034,20 @@ def main() -> None:
 
     try:
         for config_path in _collect_config_paths(args.path):
-            all_results.append(
-                process_config(
-                    config_path,
-                    args.support_brownie,
-                    enable_binary_comparison,
-                    args.cache_explorer,
-                    args.cache_github,
-                    args.yes or args.json,
-                    args.contract_filter,
-                )
+            result = process_config(
+                config_path,
+                args.support_brownie,
+                enable_binary_comparison,
+                args.cache_explorer,
+                args.cache_github,
+                args.yes or args.json,
+                args.contract_filter,
             )
+            all_results.append(result)
+            if result["interrupted"]:
+                # Partial results must never read as a verified run
+                error = "KeyboardInterrupt: run interrupted by user"
+                break
     except Exception as exc:
         # In JSON mode the report must still reach stdout; keep the traceback on stderr.
         if not args.json:
@@ -1050,21 +1056,23 @@ def main() -> None:
         error = f"{type(exc).__name__}: {exc}"
 
     # A contract filter that matches nothing across all configs is a usage error
-    if (
+    filter_unmatched = (
         error is None
-        and args.contract_filter
+        and bool(args.contract_filter)
         and sum(r["matched_count"] for r in all_results) == 0
-    ):
-        filter_label = ", ".join(args.contract_filter)
-        logger.error("No contracts matched the --contract filter", filter_label)
+    )
+    if filter_unmatched:
+        logger.error(
+            "No contracts matched the --contract filter",
+            ", ".join(args.contract_filter),
+        )
         if not args.json:
             sys.exit(1)
-        error = f"No contracts matched the --contract filter: {filter_label}"
 
     execution_time = time.time() - START_TIME
     enable_source_comparison = any(result["source_stats"] for result in all_results)
 
-    if error is None:
+    if error is None and not filter_unmatched:
         print_final_summary(
             all_results, enable_source_comparison, enable_binary_comparison
         )
@@ -1083,7 +1091,7 @@ def main() -> None:
     logger.okay(f"Done in {round(execution_time, 3)}s ✨" + " " * 100)
 
     exit_code = 0
-    if error is not None:
+    if error is not None or filter_unmatched:
         exit_code = 1
     elif source_failures + bytecode_failures > 0:
         logger.error(

--- a/diffyscan/utils/binary_verifier.py
+++ b/diffyscan/utils/binary_verifier.py
@@ -371,7 +371,7 @@ def _format_instruction_diff(local_instruction, remote_instruction, immutables):
 def _print_instruction_diffs(instruction_pairs, checkpoints, immutables):
     for prev_idx, cur_idx in zip(checkpoints, checkpoints[1:]):
         if prev_idx != cur_idx - 1:
-            print("...")
+            logger.stdout("...")
 
         local_instruction, remote_instruction = instruction_pairs[cur_idx]
         (opcode, opname, params), _ = _format_instruction_diff(
@@ -379,7 +379,7 @@ def _print_instruction_diffs(instruction_pairs, checkpoints, immutables):
             remote_instruction,
             immutables,
         )
-        print(f"{to_hex(cur_idx, 4)} {opcode} {opname} {params}")
+        logger.stdout(f"{to_hex(cur_idx, 4)} {opcode} {opname} {params}")
 
 
 def _log_string_literal_analysis(analysis: dict) -> None:

--- a/diffyscan/utils/binary_verifier.py
+++ b/diffyscan/utils/binary_verifier.py
@@ -371,7 +371,7 @@ def _format_instruction_diff(local_instruction, remote_instruction, immutables):
 def _print_instruction_diffs(instruction_pairs, checkpoints, immutables):
     for prev_idx, cur_idx in zip(checkpoints, checkpoints[1:]):
         if prev_idx != cur_idx - 1:
-            logger.stdout("...")
+            logger.raw("...")
 
         local_instruction, remote_instruction = instruction_pairs[cur_idx]
         (opcode, opname, params), _ = _format_instruction_diff(
@@ -379,7 +379,7 @@ def _print_instruction_diffs(instruction_pairs, checkpoints, immutables):
             remote_instruction,
             immutables,
         )
-        logger.stdout(f"{to_hex(cur_idx, 4)} {opcode} {opname} {params}")
+        logger.raw(f"{to_hex(cur_idx, 4)} {opcode} {opname} {params}")
 
 
 def _log_string_literal_analysis(analysis: dict) -> None:

--- a/diffyscan/utils/http_client.py
+++ b/diffyscan/utils/http_client.py
@@ -1,5 +1,6 @@
 from functools import wraps
 import os
+from urllib.parse import urlsplit
 
 import requests
 
@@ -28,14 +29,27 @@ def _build_headers(headers: dict | None) -> dict:
     return {"User-Agent": get_user_agent(), **(headers or {})}
 
 
+def _redact_url(message: str, url: str) -> str:
+    """Hide the request URL in error text: RPC paths and explorer queries carry API keys."""
+    message = message.replace(url, "[redacted URL]")
+    parsed = urlsplit(url)
+    request_target = parsed.path or "/"
+    if parsed.query:
+        request_target += f"?{parsed.query}"
+    # urllib3 connection errors include only the path and query.
+    if request_target != "/":
+        message = message.replace(request_target, "[redacted URL]")
+    return message
+
+
 def _handle_request_errors(error_class: type[BaseException]):
     """Decorator to handle HTTP request errors and convert them to custom exceptions."""
 
     def decorator(func):
         @wraps(func)
-        def wrapper(*args, **kwargs) -> requests.Response:
+        def wrapper(url: str, *args, **kwargs) -> requests.Response:
             try:
-                response: requests.Response = func(*args, **kwargs)
+                response: requests.Response = func(url, *args, **kwargs)
                 response.raise_for_status()
                 return response
             except requests.exceptions.HTTPError as exc:
@@ -43,17 +57,21 @@ def _handle_request_errors(error_class: type[BaseException]):
                 if exc.response is not None:
                     if exc.response.headers.get("cf-mitigated") == "challenge":
                         raise error_class(
-                            f"HTTP error: {exc}. The host is behind a Cloudflare "
-                            f"challenge that rejected the request; try overriding "
-                            f"the User-Agent via {USER_AGENT_ENV_VAR}"
-                        )
+                            _redact_url(f"HTTP error: {exc}", url)
+                            + ". The host is behind a Cloudflare challenge that "
+                            f"rejected the request; try overriding the User-Agent "
+                            f"via {USER_AGENT_ENV_VAR}"
+                        ) from None
                     try:
                         body = f" Response: {exc.response.text}"
                     except Exception:
                         pass
-                raise error_class(f"HTTP error: {exc}{body}")
+                # `from None` keeps the unredacted requests exception out of tracebacks
+                raise error_class(
+                    _redact_url(f"HTTP error: {exc}{body}", url)
+                ) from None
             except requests.exceptions.RequestException as exc:
-                raise error_class(str(exc))
+                raise error_class(_redact_url(str(exc), url)) from None
 
         return wrapper
 

--- a/diffyscan/utils/logger.py
+++ b/diffyscan/utils/logger.py
@@ -26,6 +26,7 @@ class Logger:
     def __init__(self, log_file):
         self.log_file = log_file
         self.level = 0
+        self.stdout_enabled = True
 
     def set_level(self, level_name: str):
         self.level = _LOG_LEVELS.get(level_name.lower(), (0,))[0]
@@ -36,6 +37,8 @@ class Logger:
             logs.write(text + "\n")
 
     def stdout(self, text, overwrite=False):
+        if not self.stdout_enabled:
+            return
         end_char = "\r" if overwrite else "\n"
         print(text, end=end_char, flush=overwrite)
 

--- a/diffyscan/utils/logger.py
+++ b/diffyscan/utils/logger.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import termtables
@@ -13,6 +14,7 @@ BOLD = "\033[1m"
 
 END = "\033[0m"
 
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 
 _LOG_LEVELS = {
     "info": (0, "🔵 [INFO] ", BLUE),
@@ -41,6 +43,11 @@ class Logger:
             return
         end_char = "\r" if overwrite else "\n"
         print(text, end=end_char, flush=overwrite)
+
+    def raw(self, text):
+        """Write a pre-formatted line to the log (uncolored) and to stdout as is."""
+        self.log(_ANSI_ESCAPE.sub("", text))
+        self.stdout(text)
 
     def _emit(self, level_name, text, value=None, overwrite=False):
         threshold, emoji, color = _LOG_LEVELS[level_name]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,82 +55,9 @@ covered by `allowed_diffs` do not fail the run.
 
 ## JSON output
 
-`--json` is meant for scripts and coding agents. Human-readable logs are not
-written to stdout (they still go to `digest/<timestamp>/logs.txt`), prompts are
-skipped, and stdout carries a single JSON document:
+`--json` replaces the logs on stdout with one JSON report for scripts and
+coding agents. The format is specified in [JSON Output Format](json-output.md).
 
 ```sh
 diffyscan path/to/config.yaml --json -E -G | jq '.summary'
 ```
-
-```json
-{
-  "diffyscan_version": "1.0.0",
-  "status": "passed | failed | error",
-  "exit_code": 0,
-  "error": null,
-  "duration_seconds": 12.3,
-  "log_file": "digest/1700000000/logs.txt",
-  "summary": {
-    "source":   { "total": 2, "exact": 1, "allowed": 1, "failed": 0 },
-    "bytecode": { "total": 2, "exact": 2, "allowed": 0, "failed": 0 },
-    "contract_errors": 0
-  },
-  "configs": [
-    {
-      "path": "path/to/config.yaml",
-      "contracts": [
-        {
-          "address": "0x...",
-          "name": "ContractName",
-          "source": {
-            "status": "allowed",
-            "files_count": 10, "files_found": 10,
-            "identical_files": 9, "files_with_diffs": 1,
-            "matched_rule": { "reason": "...", "line_ranges": [...] },
-            "matched_facets": ["line_ranges"],
-            "diff_files": [
-              {
-                "path": "contracts/Foo.sol",
-                "file_found": true,
-                "diff_report": "digest/1700000000/diffs/0x.../Foo.sol.html",
-                "hunks": [
-                  { "github": { "start": 3, "count": 1 },
-                    "explorer": { "start": 3, "count": 1 },
-                    "tag": "replace" }
-                ]
-              }
-            ],
-            "suggested_rule": null
-          },
-          "bytecode": {
-            "status": "failed",
-            "match": false,
-            "matched_rule": null,
-            "matched_facets": [],
-            "uncovered": ["offset=1234 length=32 immutable"],
-            "error": null,
-            "suggested_rule": { "reason": "TODO", "immutables": [...] }
-          }
-        }
-      ]
-    }
-  ]
-}
-```
-
-- `status` is `passed` when the exit code is 0, `failed` when a check failed or
-  the contract filter matched nothing, and `error` when the run aborted or a
-  contract was skipped because of an error. A skipped contract carries an
-  `error` string and `null` for `source` and `bytecode`; with
-  `fail_on_bytecode_comparison_error: false` this still exits 0, so check
-  `status`, not only the exit code.
-- `source` or `bytecode` is `null` when that comparison did not run.
-- `diff_files` lists only files that differ or are missing on GitHub.
-- `suggested_rule` is the `allowed_diffs` entry Diffyscan would propose for an
-  uncovered diff; replace its placeholder `reason` before adding it to a config.
-- `error` on a bytecode entry holds the compile, calldata, or simulation error
-  that turned the check into a failure.
-- A fatal error (missing config, bad token) still produces a report with
-  `status: "error"` and the exception in the top-level `error`; the traceback
-  goes to stderr.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,7 @@ in the current directory.
 | `-G, --cache-github` | Cache source files fetched from GitHub |
 | `--log-level <level>` | Set `info`, `okay`, `warn`, or `error`; defaults to `info` |
 | `-Q, --quiet` | Use the `okay` log level |
+| `-J, --json` | Print one JSON report to stdout instead of human-readable logs; implies `--yes` |
 | `-C, --contract <address>` | Check one configured address; repeat for more addresses |
 
 ## Examples
@@ -51,3 +52,85 @@ diffyscan path/to/config.yaml -E -G
 Diffyscan exits with status 1 when a source or bytecode check fails, or when a
 contract filter matches no configured address. Exact matches and differences
 covered by `allowed_diffs` do not fail the run.
+
+## JSON output
+
+`--json` is meant for scripts and coding agents. Human-readable logs are not
+written to stdout (they still go to `digest/<timestamp>/logs.txt`), prompts are
+skipped, and stdout carries a single JSON document:
+
+```sh
+diffyscan path/to/config.yaml --json -E -G | jq '.summary'
+```
+
+```json
+{
+  "diffyscan_version": "1.0.0",
+  "status": "passed | failed | error",
+  "exit_code": 0,
+  "error": null,
+  "duration_seconds": 12.3,
+  "log_file": "digest/1700000000/logs.txt",
+  "summary": {
+    "source":   { "total": 2, "exact": 1, "allowed": 1, "failed": 0 },
+    "bytecode": { "total": 2, "exact": 2, "allowed": 0, "failed": 0 },
+    "contract_errors": 0
+  },
+  "configs": [
+    {
+      "path": "path/to/config.yaml",
+      "contracts": [
+        {
+          "address": "0x...",
+          "name": "ContractName",
+          "source": {
+            "status": "allowed",
+            "files_count": 10, "files_found": 10,
+            "identical_files": 9, "files_with_diffs": 1,
+            "matched_rule": { "reason": "...", "line_ranges": [...] },
+            "matched_facets": ["line_ranges"],
+            "diff_files": [
+              {
+                "path": "contracts/Foo.sol",
+                "file_found": true,
+                "diff_report": "digest/1700000000/diffs/0x.../Foo.sol.html",
+                "hunks": [
+                  { "github": { "start": 3, "count": 1 },
+                    "explorer": { "start": 3, "count": 1 },
+                    "tag": "replace" }
+                ]
+              }
+            ],
+            "suggested_rule": null
+          },
+          "bytecode": {
+            "status": "failed",
+            "match": false,
+            "matched_rule": null,
+            "matched_facets": [],
+            "uncovered": ["offset=1234 length=32 immutable"],
+            "error": null,
+            "suggested_rule": { "reason": "TODO", "immutables": [...] }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+- `status` is `passed` when the exit code is 0, `failed` when a check failed or
+  the contract filter matched nothing, and `error` when the run aborted or a
+  contract was skipped because of an error. A skipped contract carries an
+  `error` string and `null` for `source` and `bytecode`; with
+  `fail_on_bytecode_comparison_error: false` this still exits 0, so check
+  `status`, not only the exit code.
+- `source` or `bytecode` is `null` when that comparison did not run.
+- `diff_files` lists only files that differ or are missing on GitHub.
+- `suggested_rule` is the `allowed_diffs` entry Diffyscan would propose for an
+  uncovered diff; replace its placeholder `reason` before adding it to a config.
+- `error` on a bytecode entry holds the compile, calldata, or simulation error
+  that turned the check into a failure.
+- A fatal error (missing config, bad token) still produces a report with
+  `status: "error"` and the exception in the top-level `error`; the traceback
+  goes to stderr.

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -135,3 +135,10 @@ messages:
 ```sh
 diffyscan path/to/configs --yes --quiet
 ```
+
+For scripts and coding agents, `--json` replaces the logs on stdout with one
+JSON report (see [CLI Reference](cli.md#json-output)):
+
+```sh
+diffyscan path/to/configs --json
+```

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -137,7 +137,7 @@ diffyscan path/to/configs --yes --quiet
 ```
 
 For scripts and coding agents, `--json` replaces the logs on stdout with one
-JSON report (see [CLI Reference](cli.md#json-output)):
+JSON report (format: [JSON Output Format](json-output.md)):
 
 ```sh
 diffyscan path/to/configs --json

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -52,6 +52,7 @@ diffyscan path/to/configs
 ```
 
 Directory discovery is not recursive. Pass a nested directory separately.
+A directory without config files directly inside it is an error.
 
 With no path, Diffyscan checks for `config.json`, `config.yaml`, then
 `config.yml` in the current directory.

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -2,9 +2,9 @@
 
 [Back to README](../README.md) · [CLI Reference](cli.md)
 
-`diffyscan <config> --json` writes exactly one JSON object to stdout and nothing
-else. Human-readable logs go to the file named in `log_file`; tracebacks go to
-stderr. `--json` implies `--yes`, so the run never waits for input.
+`diffyscan <config> --json` writes one JSON object to stdout. The
+human-readable log goes to the file named in `log_file`, tracebacks go to
+stderr. `--json` implies `--yes`, so the run does not prompt.
 
 ```sh
 diffyscan path/to/config.yaml --json -E -G
@@ -12,26 +12,26 @@ diffyscan path/to/config.yaml --json -E -G
 
 ## Rules for parsers
 
-- Keys whose value would be `null` or an empty list are omitted. Treat a missing
-  key as "nothing to report". `summary` and `contracts` are always present.
-- Check `status` before the exit code. A contract skipped because of an error
-  keeps the exit code at 0 when the config sets
-  `fail_on_bytecode_comparison_error: false`, but `status` becomes `error`.
-- Addresses are printed as written in the config (checksummed or not). Compare
-  them case-insensitively.
-- New keys may be added in later versions; unknown keys should be ignored.
+- Keys with a `null` or empty-list value are omitted. A missing key means
+  nothing to report. `summary` and `contracts` are present in every report.
+- Read `status` before the exit code. With
+  `fail_on_bytecode_comparison_error: false` a contract skipped because of an
+  error leaves the exit code at 0, while `status` becomes `error`.
+- Addresses appear as written in the config, checksummed or not. Compare them
+  case-insensitively.
+- Later versions may add keys. Ignore unknown keys.
 
 ## Top level
 
 | Key | Type | Meaning |
 | --- | --- | --- |
-| `status` | `"passed"`, `"failed"`, `"error"` | `passed`: exit code 0 and every contract verified. `failed`: an unallowed diff, or `--contract` matched nothing. `error`: the run aborted, or at least one contract was skipped because of an error. |
-| `exit_code` | int | Process exit code, same as without `--json`. |
-| `error` | string | Only when the run aborted (missing config, bad token). `"<ExceptionType>: <message>"`. |
+| `status` | `"passed"`, `"failed"`, `"error"` | `passed`: exit code 0 and each contract verified. `failed`: an unallowed diff, or `--contract` matched nothing. `error`: the run aborted, or at least one contract was skipped because of an error. |
+| `exit_code` | int | Process exit code, the same as without `--json`. |
+| `error` | string | Present when the run aborted, for example on a missing config or a bad token. Format: `"<ExceptionType>: <message>"`. |
 | `duration_seconds` | float | Wall time of the run. |
-| `log_file` | string | Path to the full human-readable log of this run. |
-| `summary` | object | Counters, see below. |
-| `contracts` | array | One entry per checked contract, see below. |
+| `log_file` | string | Path to the human-readable log of this run. |
+| `summary` | object | Counters, described below. |
+| `contracts` | array | One entry per checked contract, described below. |
 
 ### `summary`
 
@@ -43,48 +43,48 @@ diffyscan path/to/config.yaml --json -E -G
 }
 ```
 
-`source` or `bytecode` is absent when that comparison did not run for any
-contract. `contract_errors` is absent when zero.
+`source` or `bytecode` is absent when that comparison ran for no contract.
+`contract_errors` is absent when zero.
 
 ## `contracts[]`
 
-Every entry has `config` (path of the config file), `address`, and `name`.
-Then one of:
+Each entry has `config` (path of the config file), `address`, and `name`, plus
+either:
 
-- `source` and/or `bytecode`: the comparison results.
-- `error`: the contract was skipped before any comparison finished. `source`
-  and `bytecode` are absent.
+- `source` and/or `bytecode` with the comparison results, or
+- `error` when the contract was skipped before a comparison finished. `source`
+  and `bytecode` are then absent.
 
 ### `source`
 
 | Key | Present when | Meaning |
 | --- | --- | --- |
-| `status` | always | `exact`, `allowed`, or `failed`. |
-| `files` | always | Number of source files in the explorer-verified set. |
-| `missing` | some files not found on GitHub | Count of files missing at the pinned commit. |
-| `with_diffs` | some files differ | Count of files with at least one hunk. |
-| `diffs` | any file differs or is missing | One object per such file: `path`, `report` (HTML diff path), `missing: true` when absent on GitHub, `hunks`. |
+| `status` | in every entry | `exact`, `allowed`, or `failed`. |
+| `files` | in every entry | Number of source files in the explorer-verified set. |
+| `missing` | a file is absent on GitHub | Count of files absent at the pinned commit. |
+| `with_diffs` | a file differs | Count of files with at least one hunk. |
+| `diffs` | a file differs or is absent | One object per such file: `path`, `report` (path of the HTML diff), `missing: true` when absent on GitHub, `hunks`. |
 | `facets`, `reason` | `status` is `allowed` | Facets of the matching `allowed_diffs` rule (`line_ranges`, `files`, `any`) and its `reason`. |
-| `suggested_rule` | `status` is `failed` | Ready `allowed_diffs.source` entry covering the uncovered diff. Replace its placeholder `reason`. |
+| `suggested_rule` | `status` is `failed` | An `allowed_diffs.source` entry that covers the uncovered diff. Replace its placeholder `reason` before use. |
 
-A hunk is one `SequenceMatcher` opcode with 1-based line numbers:
+A hunk is one `difflib.SequenceMatcher` opcode with 1-based line numbers:
 
 ```json
 { "github": { "start": 12, "count": 1 }, "explorer": { "start": 12, "count": 2 }, "tag": "replace" }
 ```
 
-`tag` is `replace`, `insert`, or `delete`, from the GitHub side to the explorer
-side. `count: 0` marks the insertion point on the side that has no lines.
+`tag` is `replace`, `insert`, or `delete`, read from the GitHub side to the
+explorer side. `count: 0` marks the insertion point on the side without lines.
 
 ### `bytecode`
 
 | Key | Present when | Meaning |
 | --- | --- | --- |
-| `status` | always | `exact`, `allowed`, or `failed`. |
+| `status` | in every entry | `exact`, `allowed`, or `failed`. |
 | `uncovered` | `status` is `failed` and the comparison ran | Labels of differences no rule covers: `offset=<n> length=<n>[ immutable]`, `cbor_metadata`, `string_literal`, `runtime_length`. |
-| `error` | the comparison itself failed | Compile, calldata, or deployment-simulation error text. `status` is `failed`. |
+| `error` | the comparison itself failed | Text of the compile, calldata, or deployment-simulation error. `status` is `failed`. |
 | `facets`, `reason` | `status` is `allowed` | Facets of the matching rule (`immutables`, `byte_ranges`, `cbor_metadata`, `constructor_args`, `constructor_calldata`, `any`) and its `reason`. |
-| `suggested_rule` | `status` is `failed` and a diff was analyzed | Ready `allowed_diffs.bytecode` entry: `immutables` with observed on-chain values when only immutable slots differ, otherwise `byte_ranges`, plus `cbor_metadata: true` when metadata differs. |
+| `suggested_rule` | `status` is `failed` and a diff was analyzed | An `allowed_diffs.bytecode` entry: `immutables` with the observed on-chain values when only immutable slots differ, otherwise `byte_ranges`; `cbor_metadata: true` is added when metadata differs. |
 
 ## Example
 
@@ -128,7 +128,7 @@ side. `count: 0` marks the insertion point on the side that has no lines.
 }
 ```
 
-Useful `jq` one-liners:
+`jq` examples:
 
 ```sh
 # Overall verdict
@@ -137,6 +137,6 @@ diffyscan cfg.yaml --json | jq -r .status
 # Contracts that need attention
 diffyscan cfg.yaml --json | jq '.contracts[] | select(.error or .source.status=="failed" or .bytecode.status=="failed")'
 
-# Ready-to-paste allowlist suggestions
+# Allowlist suggestions
 diffyscan cfg.yaml --json | jq '.contracts[] | {address, source: .source.suggested_rule, bytecode: .bytecode.suggested_rule} | select(.source or .bytecode)'
 ```

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -25,9 +25,9 @@ diffyscan path/to/config.yaml --json -E -G
 
 | Key | Type | Meaning |
 | --- | --- | --- |
-| `status` | `"passed"`, `"failed"`, `"error"` | `passed`: exit code 0 and each contract verified. `failed`: an unallowed diff, or `--contract` matched nothing. `error`: the run aborted, or at least one contract was skipped because of an error. |
+| `status` | `"passed"`, `"failed"`, `"error"` | `passed`: exit code 0 and each contract verified. `failed`: an unallowed diff, or `--contract` matched nothing. `error`: the run aborted or was interrupted, or at least one contract was skipped because of an error. |
 | `exit_code` | int | Process exit code, the same as without `--json`. |
-| `error` | string | Present when the run aborted, for example on a missing config or a bad token. Format: `"<ExceptionType>: <message>"`. |
+| `error` | string | Present when the run aborted, for example on a missing config or a bad token, or was interrupted with Ctrl+C. Format: `"<ExceptionType>: <message>"`. |
 | `duration_seconds` | float | Wall time of the run. |
 | `log_file` | string | Path to the human-readable log of this run. |
 | `summary` | object | Counters, described below. |

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -1,0 +1,142 @@
+# JSON Output Format
+
+[Back to README](../README.md) · [CLI Reference](cli.md)
+
+`diffyscan <config> --json` writes exactly one JSON object to stdout and nothing
+else. Human-readable logs go to the file named in `log_file`; tracebacks go to
+stderr. `--json` implies `--yes`, so the run never waits for input.
+
+```sh
+diffyscan path/to/config.yaml --json -E -G
+```
+
+## Rules for parsers
+
+- Keys whose value would be `null` or an empty list are omitted. Treat a missing
+  key as "nothing to report". `summary` and `contracts` are always present.
+- Check `status` before the exit code. A contract skipped because of an error
+  keeps the exit code at 0 when the config sets
+  `fail_on_bytecode_comparison_error: false`, but `status` becomes `error`.
+- Addresses are printed as written in the config (checksummed or not). Compare
+  them case-insensitively.
+- New keys may be added in later versions; unknown keys should be ignored.
+
+## Top level
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `status` | `"passed"`, `"failed"`, `"error"` | `passed`: exit code 0 and every contract verified. `failed`: an unallowed diff, or `--contract` matched nothing. `error`: the run aborted, or at least one contract was skipped because of an error. |
+| `exit_code` | int | Process exit code, same as without `--json`. |
+| `error` | string | Only when the run aborted (missing config, bad token). `"<ExceptionType>: <message>"`. |
+| `duration_seconds` | float | Wall time of the run. |
+| `log_file` | string | Path to the full human-readable log of this run. |
+| `summary` | object | Counters, see below. |
+| `contracts` | array | One entry per checked contract, see below. |
+
+### `summary`
+
+```json
+"summary": {
+  "source":   { "total": 4, "exact": 3, "allowed": 1, "failed": 0 },
+  "bytecode": { "total": 4, "exact": 2, "allowed": 1, "failed": 1 },
+  "contract_errors": 1
+}
+```
+
+`source` or `bytecode` is absent when that comparison did not run for any
+contract. `contract_errors` is absent when zero.
+
+## `contracts[]`
+
+Every entry has `config` (path of the config file), `address`, and `name`.
+Then one of:
+
+- `source` and/or `bytecode`: the comparison results.
+- `error`: the contract was skipped before any comparison finished. `source`
+  and `bytecode` are absent.
+
+### `source`
+
+| Key | Present when | Meaning |
+| --- | --- | --- |
+| `status` | always | `exact`, `allowed`, or `failed`. |
+| `files` | always | Number of source files in the explorer-verified set. |
+| `missing` | some files not found on GitHub | Count of files missing at the pinned commit. |
+| `with_diffs` | some files differ | Count of files with at least one hunk. |
+| `diffs` | any file differs or is missing | One object per such file: `path`, `report` (HTML diff path), `missing: true` when absent on GitHub, `hunks`. |
+| `facets`, `reason` | `status` is `allowed` | Facets of the matching `allowed_diffs` rule (`line_ranges`, `files`, `any`) and its `reason`. |
+| `suggested_rule` | `status` is `failed` | Ready `allowed_diffs.source` entry covering the uncovered diff. Replace its placeholder `reason`. |
+
+A hunk is one `SequenceMatcher` opcode with 1-based line numbers:
+
+```json
+{ "github": { "start": 12, "count": 1 }, "explorer": { "start": 12, "count": 2 }, "tag": "replace" }
+```
+
+`tag` is `replace`, `insert`, or `delete`, from the GitHub side to the explorer
+side. `count: 0` marks the insertion point on the side that has no lines.
+
+### `bytecode`
+
+| Key | Present when | Meaning |
+| --- | --- | --- |
+| `status` | always | `exact`, `allowed`, or `failed`. |
+| `uncovered` | `status` is `failed` and the comparison ran | Labels of differences no rule covers: `offset=<n> length=<n>[ immutable]`, `cbor_metadata`, `string_literal`, `runtime_length`. |
+| `error` | the comparison itself failed | Compile, calldata, or deployment-simulation error text. `status` is `failed`. |
+| `facets`, `reason` | `status` is `allowed` | Facets of the matching rule (`immutables`, `byte_ranges`, `cbor_metadata`, `constructor_args`, `constructor_calldata`, `any`) and its `reason`. |
+| `suggested_rule` | `status` is `failed` and a diff was analyzed | Ready `allowed_diffs.bytecode` entry: `immutables` with observed on-chain values when only immutable slots differ, otherwise `byte_ranges`, plus `cbor_metadata: true` when metadata differs. |
+
+## Example
+
+```json
+{
+  "status": "failed",
+  "exit_code": 1,
+  "duration_seconds": 41.2,
+  "log_file": "digest/1788770889/logs.txt",
+  "summary": {
+    "source": { "total": 2, "exact": 2, "allowed": 0, "failed": 0 },
+    "bytecode": { "total": 2, "exact": 0, "allowed": 1, "failed": 1 }
+  },
+  "contracts": [
+    {
+      "config": "configs/example/mainnet/config.yaml",
+      "address": "0x05Af8e10964Ad5536a643Ce7b9C831F45DC9D43e",
+      "name": "Guard",
+      "source": { "status": "exact", "files": 26 },
+      "bytecode": {
+        "status": "allowed",
+        "facets": ["immutables"],
+        "reason": "Bytecode differs only at immutable slots that depend on address(this)"
+      }
+    },
+    {
+      "config": "configs/example/mainnet/config.yaml",
+      "address": "0x7305bB45aF91893B7BCaF0Ad8Eae37cb16820Bb8",
+      "name": "Proxy",
+      "source": { "status": "exact", "files": 14 },
+      "bytecode": {
+        "status": "failed",
+        "uncovered": ["offset=1234 length=32 immutable"],
+        "suggested_rule": {
+          "reason": "TODO: explain why this diff is expected",
+          "immutables": [{ "offset": 1234, "value": "0x00..01" }]
+        }
+      }
+    }
+  ]
+}
+```
+
+Useful `jq` one-liners:
+
+```sh
+# Overall verdict
+diffyscan cfg.yaml --json | jq -r .status
+
+# Contracts that need attention
+diffyscan cfg.yaml --json | jq '.contracts[] | select(.error or .source.status=="failed" or .bytecode.status=="failed")'
+
+# Ready-to-paste allowlist suggestions
+diffyscan cfg.yaml --json | jq '.contracts[] | {address, source: .source.suggested_rule, bytecode: .bytecode.suggested_rule} | select(.source or .bytecode)'
+```

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -6,6 +6,9 @@
 human-readable log goes to the file named in `log_file`, tracebacks go to
 stderr. `--json` implies `--yes`, so the run does not prompt.
 
+A config with `source_comparison: false` combined with
+`--skip-binary-comparison` is an error: at least one comparison must be enabled.
+
 ```sh
 diffyscan path/to/config.yaml --json -E -G
 ```
@@ -25,7 +28,7 @@ diffyscan path/to/config.yaml --json -E -G
 
 | Key | Type | Meaning |
 | --- | --- | --- |
-| `status` | `"passed"`, `"failed"`, `"error"` | `passed`: exit code 0 and each contract verified. `failed`: an unallowed diff, or `--contract` matched nothing. `error`: the run aborted or was interrupted, or at least one contract was skipped because of an error. |
+| `status` | `"passed"`, `"failed"`, `"error"` | `passed`: exit code 0 and each contract verified. `failed`: an unallowed diff, or no contract was checked (empty configs, or `--contract` matched nothing). `error`: the run aborted or was interrupted, or at least one contract was skipped because of an error. |
 | `exit_code` | int | Process exit code, the same as without `--json`. |
 | `error` | string | Present when the run aborted, for example on a missing config or a bad token, or was interrupted with Ctrl+C. Format: `"<ExceptionType>: <message>"`. Contracts checked before the abort stay in `summary` and `contracts`. |
 | `duration_seconds` | float | Wall time of the run. |

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -27,7 +27,7 @@ diffyscan path/to/config.yaml --json -E -G
 | --- | --- | --- |
 | `status` | `"passed"`, `"failed"`, `"error"` | `passed`: exit code 0 and each contract verified. `failed`: an unallowed diff, or `--contract` matched nothing. `error`: the run aborted or was interrupted, or at least one contract was skipped because of an error. |
 | `exit_code` | int | Process exit code, the same as without `--json`. |
-| `error` | string | Present when the run aborted, for example on a missing config or a bad token, or was interrupted with Ctrl+C. Format: `"<ExceptionType>: <message>"`. |
+| `error` | string | Present when the run aborted, for example on a missing config or a bad token, or was interrupted with Ctrl+C. Format: `"<ExceptionType>: <message>"`. Contracts checked before the abort stay in `summary` and `contracts`. |
 | `duration_seconds` | float | Wall time of the run. |
 | `log_file` | string | Path to the human-readable log of this run. |
 | `summary` | object | Counters, described below. |

--- a/tests/test_diffyscan_allowlist_runtime.py
+++ b/tests/test_diffyscan_allowlist_runtime.py
@@ -97,6 +97,41 @@ def test_any_rule_can_suppress_deployment_simulation_errors(monkeypatch):
     assert result["bytecode_stats"][0]["matched_facets"] == ["any"]
 
 
+def test_process_config_keeps_results_when_a_later_contract_fails(monkeypatch):
+    second = "0x0000000000000000000000000000000000000002"
+    config = _config_with_any_rule()
+    config["contracts"] = {ADDR: "Test", second: "Broken"}
+    _stub_process_config_dependencies(monkeypatch, config)
+
+    def explorer(token, hostname, address, *args, **kwargs):
+        if address == second:
+            raise RuntimeError("explorer returned 401")
+        return {"name": "Test", "solcInput": {"sources": {}}}
+
+    monkeypatch.setattr(runner, "get_contract_from_explorer", explorer)
+    monkeypatch.setattr(
+        runner,
+        "run_bytecode_diff",
+        lambda address, name, *args, **kwargs: {
+            "contract_address": address,
+            "contract_name": name,
+            "status": "exact",
+        },
+    )
+
+    result = runner.process_config(
+        "config.json",
+        recursive_parsing=False,
+        enable_binary_comparison=True,
+        cache_explorer=False,
+        cache_github=False,
+        skip_user_input=True,
+    )
+
+    assert [stat["contract_address"] for stat in result["bytecode_stats"]] == [ADDR]
+    assert str(result["error"]) == "explorer returned 401"
+
+
 def test_process_config_normalizes_explorer_chain_id(monkeypatch):
     config = {
         "contracts": {ADDR: "Test"},

--- a/tests/test_diffyscan_allowlist_runtime.py
+++ b/tests/test_diffyscan_allowlist_runtime.py
@@ -63,6 +63,8 @@ def test_any_rule_does_not_suppress_compile_errors(monkeypatch):
             "matched_rule": None,
             "matched_facets": [],
             "suggestion_entry": None,
+            "uncovered": [],
+            "error": "Failed to compile contract: boom",
         }
     ]
 

--- a/tests/test_diffyscan_allowlist_runtime.py
+++ b/tests/test_diffyscan_allowlist_runtime.py
@@ -137,10 +137,11 @@ def test_process_config_normalizes_explorer_chain_id(monkeypatch):
         "contracts": {ADDR: "Test"},
         "explorer_hostname": "api.etherscan.io",
         "explorer_chain_id": "1",
-        "source_comparison": False,
+        "source_comparison": True,
     }
     captured = {}
     _stub_process_config_dependencies(monkeypatch, config)
+    monkeypatch.setattr(runner, "run_source_diff", lambda *args: {})
 
     def fake_get_contract_from_explorer(
         token,
@@ -175,10 +176,11 @@ def test_process_config_resolves_explorer_hostname_from_env(monkeypatch):
     config = {
         "contracts": {ADDR: "Test"},
         "explorer_hostname_env_var": "EXPLORER_API_HOSTNAME",
-        "source_comparison": False,
+        "source_comparison": True,
     }
     captured = {}
     _stub_process_config_dependencies(monkeypatch, config)
+    monkeypatch.setattr(runner, "run_source_diff", lambda *args: {})
 
     def fake_load_env(variable_name, **kwargs):
         return {

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -152,6 +152,79 @@ def test_plain_http_error_still_includes_response_body(monkeypatch):
     assert "Response: rate limited" in message
 
 
+def test_http_error_hides_request_url_with_credentials(monkeypatch):
+    from diffyscan.utils.custom_exceptions import ExplorerError
+
+    url = "https://example.com/api?apikey=SECRET-TOKEN"
+
+    class LeakyResponse(FailingResponse):
+        def raise_for_status(self):
+            import requests
+
+            raise requests.exceptions.HTTPError(
+                f"401 Client Error: Unauthorized for url: {url}",
+                response=self,  # type: ignore[arg-type]
+            )
+
+    monkeypatch.setattr(
+        f"{HTTP_CLIENT_MODULE}.requests.get",
+        lambda url, headers=None: LeakyResponse({}, "denied"),
+    )
+    with pytest.raises(ExplorerError) as exc_info:
+        fetch(url)
+
+    message = str(exc_info.value)
+    assert "SECRET-TOKEN" not in message
+    assert "401 Client Error" in message
+    assert "Response: denied" in message
+    # The chained requests exception would print the raw URL in tracebacks
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__ is True
+
+
+def test_connection_error_hides_request_url(monkeypatch):
+    import requests
+
+    from diffyscan.utils.custom_exceptions import NodeError
+
+    url = "https://rpc.example.com/v3/SECRET-KEY"
+
+    def failing_post(url, data=None, headers=None):
+        raise requests.exceptions.ConnectionError(f"Failed to connect to {url}")
+
+    monkeypatch.setattr(f"{HTTP_CLIENT_MODULE}.requests.post", failing_post)
+    with pytest.raises(NodeError) as exc_info:
+        pull(url, "{}")
+
+    assert "SECRET-KEY" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize("path", ["/v3/SECRET-KEY", "/api?apikey=SECRET-KEY"])
+def test_connection_error_hides_relative_request_url(monkeypatch, path):
+    import traceback
+
+    import requests
+    from urllib3.connectionpool import HTTPSConnectionPool
+    from urllib3.exceptions import MaxRetryError
+
+    from diffyscan.utils.custom_exceptions import NodeError
+
+    def failing_post(url, data=None, headers=None):
+        raise requests.exceptions.ConnectionError(
+            MaxRetryError(
+                HTTPSConnectionPool("rpc.example.com"), path, OSError("offline")
+            )
+        )
+
+    monkeypatch.setattr(f"{HTTP_CLIENT_MODULE}.requests.post", failing_post)
+    with pytest.raises(NodeError) as exc_info:
+        pull(f"https://rpc.example.com{path}", "{}")
+
+    assert "SECRET-KEY" not in str(exc_info.value)
+    assert "SECRET-KEY" not in "".join(traceback.format_exception(exc_info.value))
+    assert "Max retries exceeded" in str(exc_info.value)
+
+
 def test_no_direct_requests_usage_outside_http_client():
     package_dir = pathlib.Path(__file__).parent.parent / "diffyscan"
     direct_call_re = re.compile(

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -277,6 +277,68 @@ def test_json_mode_reports_unmatched_filter_as_failed(monkeypatch, capsys):
     assert report["contracts"] == []
 
 
+def test_json_mode_reports_empty_configs_as_failed(monkeypatch, capsys):
+    def nothing_to_check(path, *args):
+        result = _result([], [], path)
+        result["matched_count"] = 0
+        return result
+
+    code = _run_main(monkeypatch, ["config.yaml", "--json"], nothing_to_check)
+
+    assert code == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "failed"
+    assert "error" not in report
+
+
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_run_rejects_disabled_comparisons(monkeypatch, capsys, json_mode):
+    monkeypatch.setattr(
+        runner,
+        "load_config",
+        lambda path: {
+            "contracts": {ADDR: "Test"},
+            "explorer_hostname": "api.etherscan.io",
+            "source_comparison": False,
+        },
+    )
+    monkeypatch.setattr(runner, "_load_explorer_token", lambda cfg: "dummy")
+    monkeypatch.setattr(runner, "load_env", lambda *args, **kwargs: "dummy")
+    monkeypatch.setattr(runner, "get_contract_from_explorer", lambda *args: {})
+    argv = ["config.yaml", "--skip-binary-comparison"]
+    if json_mode:
+        code = _run_main(monkeypatch, [*argv, "--json"], runner.process_config)
+        report = json.loads(capsys.readouterr().out)
+        assert code == 1
+        assert report["status"] == "error"
+        assert "Both source and bytecode comparisons are disabled" in report["error"]
+    else:
+        with pytest.raises(
+            ValueError, match="Both source and bytecode comparisons are disabled"
+        ):
+            _run_main(monkeypatch, argv, runner.process_config)
+
+
+def test_json_mode_reports_interrupt_during_setup_as_error(monkeypatch, capsys):
+    def interrupted(*args):
+        raise KeyboardInterrupt
+
+    code = _run_main(monkeypatch, ["config.yaml", "--json"], interrupted)
+
+    assert code == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "error"
+    assert report["error"] == "KeyboardInterrupt: run interrupted by user"
+
+
+def test_directory_without_config_files_is_an_error(tmp_path):
+    (tmp_path / "mainnet").mkdir()
+    (tmp_path / "mainnet" / "core.yaml").write_text("contracts: {}\n")
+
+    with pytest.raises(FileNotFoundError, match="not recursive"):
+        runner._collect_config_paths(str(tmp_path))
+
+
 def test_human_mode_still_raises(monkeypatch):
     def boom(*args):
         raise RuntimeError("explorer is down")

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -75,6 +75,7 @@ def _result(source_stats, bytecode_stats, path="config.yaml", contract_errors=No
         "contract_errors": contract_errors or [],
         "config_path": path,
         "matched_count": 1,
+        "interrupted": False,
     }
 
 
@@ -218,6 +219,39 @@ def test_json_mode_reports_exceptions_instead_of_crashing(monkeypatch, capsys):
     report = json.loads(capsys.readouterr().out)
     assert report["status"] == "error"
     assert report["error"] == "RuntimeError: explorer is down"
+
+
+def test_json_mode_reports_interrupted_run_as_error(monkeypatch, capsys):
+    def interrupted(path, *args):
+        result = _result([], [_bytecode_stat()], path)
+        result["interrupted"] = True
+        return result
+
+    code = _run_main(monkeypatch, ["config.yaml", "--json"], interrupted)
+
+    assert code == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "error"
+    assert report["error"] == "KeyboardInterrupt: run interrupted by user"
+    # Partial results are still reported so the consumer sees what was checked.
+    assert report["summary"]["bytecode"]["exact"] == 1
+
+
+def test_json_mode_reports_unmatched_filter_as_failed(monkeypatch, capsys):
+    def nothing_matched(path, *args):
+        result = _result([], [], path)
+        result["matched_count"] = 0
+        return result
+
+    code = _run_main(
+        monkeypatch, ["config.yaml", "--json", "--contract", ADDR], nothing_matched
+    )
+
+    assert code == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "failed"
+    assert "error" not in report
+    assert report["contracts"] == []
 
 
 def test_human_mode_still_raises(monkeypatch):

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -88,27 +88,48 @@ def test_report_merges_source_and_bytecode_per_contract():
 
     assert report["status"] == "failed"
     assert report["exit_code"] == 1
-    assert report["error"] is None
+    assert "error" not in report
     assert report["duration_seconds"] == 1.235
     assert report["summary"] == {
         "source": {"total": 1, "exact": 0, "allowed": 0, "failed": 1},
         "bytecode": {"total": 1, "exact": 1, "allowed": 0, "failed": 0},
-        "contract_errors": 0,
     }
 
-    [config] = report["configs"]
-    assert config["path"] == "config.yaml"
-    [contract] = config["contracts"]
+    [contract] = report["contracts"]
+    assert contract["config"] == "config.yaml"
     assert contract["address"] == ADDR
     assert contract["name"] == "Test"
-    assert contract["bytecode"]["status"] == "exact"
+    # Clean results carry only their status; empty fields are omitted.
+    assert contract["bytecode"] == {"status": "exact"}
     assert contract["source"]["status"] == "failed"
+    assert contract["source"]["files"] == 2
+    assert contract["source"]["with_diffs"] == 1
+    assert "missing" not in contract["source"]
     assert contract["source"]["suggested_rule"] == {"reason": "TODO", "line_ranges": []}
     # Only files that differ or are missing are listed.
-    assert [f["path"] for f in contract["source"]["diff_files"]] == [
-        "contracts/Changed.sol"
-    ]
-    assert contract["source"]["diff_files"][0]["hunks"][0]["tag"] == "replace"
+    [diff] = contract["source"]["diffs"]
+    assert diff["path"] == "contracts/Changed.sol"
+    assert diff["report"] == "digest/1/diffs/Changed.sol.html"
+    assert diff["hunks"][0]["tag"] == "replace"
+
+
+def test_allowed_diff_keeps_reason_and_facets_only():
+    stat = _bytecode_stat("allowed")
+    stat["matched_rule"] = {
+        "reason": "proxy admin immutable",
+        "immutables": [{"offset": 1, "value": "0x01"}],
+    }
+    stat["matched_facets"] = ["immutables"]
+
+    report = runner.build_json_report(
+        [_result([], [stat])], exit_code=0, error=None, duration_seconds=0
+    )
+
+    assert report["contracts"][0]["bytecode"] == {
+        "status": "allowed",
+        "facets": ["immutables"],
+        "reason": "proxy admin immutable",
+    }
 
 
 def test_report_status_reflects_error_and_pass():
@@ -116,14 +137,16 @@ def test_report_status_reflects_error_and_pass():
         [_result([], [_bytecode_stat()])], exit_code=0, error=None, duration_seconds=0
     )
     assert passed["status"] == "passed"
-    assert passed["configs"][0]["contracts"][0]["source"] is None
+    assert "source" not in passed["contracts"][0]
+    assert "source" not in passed["summary"]
 
     errored = runner.build_json_report(
         [], exit_code=1, error="FileNotFoundError: nope", duration_seconds=0
     )
     assert errored["status"] == "error"
     assert errored["error"] == "FileNotFoundError: nope"
-    assert errored["configs"] == []
+    assert errored["contracts"] == []
+    assert errored["summary"] == {}
 
 
 def test_swallowed_contract_errors_surface_as_error_status():
@@ -143,10 +166,10 @@ def test_swallowed_contract_errors_surface_as_error_status():
     # report must not read as "passed" when nothing was verified.
     assert report["status"] == "error"
     assert report["exit_code"] == 0
-    assert report["summary"]["contract_errors"] == 1
-    [contract] = report["configs"][0]["contracts"]
+    assert report["summary"] == {"contract_errors": 1}
+    [contract] = report["contracts"]
     assert contract["error"] == failure["error"]
-    assert contract["source"] is None and contract["bytecode"] is None
+    assert "source" not in contract and "bytecode" not in contract
 
 
 def test_logger_stdout_can_be_muted(capsys, tmp_path):

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -1,0 +1,209 @@
+"""Tests for the --json machine-readable output mode."""
+
+import json
+
+import pytest
+
+import diffyscan.diffyscan as runner
+from diffyscan.utils.logger import Logger
+
+ADDR = "0x0000000000000000000000000000000000000001"
+
+
+@pytest.fixture(autouse=True)
+def _restore_logger_stdout():
+    yield
+    runner.logger.stdout_enabled = True
+
+
+def _source_stat(status="failed"):
+    return {
+        "contract_address": ADDR,
+        "contract_name": "Test",
+        "status": status,
+        "files_count": 2,
+        "files_found": 2,
+        "identical_files": 1,
+        "files_with_diffs": 1,
+        "matched_rule": None,
+        "matched_facets": [],
+        "suggestion_entry": {"reason": "TODO", "line_ranges": []},
+        "has_diff": True,
+        "files": [
+            {
+                "path": "contracts/Same.sol",
+                "filename": "Same.sol",
+                "origin": "contracts",
+                "file_found": True,
+                "diff_report_filename": "digest/1/diffs/Same.sol.html",
+                "diffs_count": 0,
+                "hunks": [],
+                "github_line_count": 10,
+                "explorer_line_count": 10,
+            },
+            {
+                "path": "contracts/Changed.sol",
+                "filename": "Changed.sol",
+                "origin": "contracts",
+                "file_found": True,
+                "diff_report_filename": "digest/1/diffs/Changed.sol.html",
+                "diffs_count": 4,
+                "hunks": [
+                    {
+                        "github": {"start": 3, "count": 1},
+                        "explorer": {"start": 3, "count": 1},
+                        "tag": "replace",
+                    }
+                ],
+                "github_line_count": 10,
+                "explorer_line_count": 10,
+            },
+        ],
+    }
+
+
+def _bytecode_stat(status="exact"):
+    return runner._bytecode_result(
+        ADDR, "Test", status=status, match=status == "exact", has_diff=False
+    )
+
+
+def _result(source_stats, bytecode_stats, path="config.yaml", contract_errors=None):
+    return {
+        "source_stats": source_stats,
+        "bytecode_stats": bytecode_stats,
+        "contract_errors": contract_errors or [],
+        "config_path": path,
+        "matched_count": 1,
+    }
+
+
+def test_report_merges_source_and_bytecode_per_contract():
+    report = runner.build_json_report(
+        [_result([_source_stat()], [_bytecode_stat()])],
+        exit_code=1,
+        error=None,
+        duration_seconds=1.23456,
+    )
+
+    assert report["status"] == "failed"
+    assert report["exit_code"] == 1
+    assert report["error"] is None
+    assert report["duration_seconds"] == 1.235
+    assert report["summary"] == {
+        "source": {"total": 1, "exact": 0, "allowed": 0, "failed": 1},
+        "bytecode": {"total": 1, "exact": 1, "allowed": 0, "failed": 0},
+        "contract_errors": 0,
+    }
+
+    [config] = report["configs"]
+    assert config["path"] == "config.yaml"
+    [contract] = config["contracts"]
+    assert contract["address"] == ADDR
+    assert contract["name"] == "Test"
+    assert contract["bytecode"]["status"] == "exact"
+    assert contract["source"]["status"] == "failed"
+    assert contract["source"]["suggested_rule"] == {"reason": "TODO", "line_ranges": []}
+    # Only files that differ or are missing are listed.
+    assert [f["path"] for f in contract["source"]["diff_files"]] == [
+        "contracts/Changed.sol"
+    ]
+    assert contract["source"]["diff_files"][0]["hunks"][0]["tag"] == "replace"
+
+
+def test_report_status_reflects_error_and_pass():
+    passed = runner.build_json_report(
+        [_result([], [_bytecode_stat()])], exit_code=0, error=None, duration_seconds=0
+    )
+    assert passed["status"] == "passed"
+    assert passed["configs"][0]["contracts"][0]["source"] is None
+
+    errored = runner.build_json_report(
+        [], exit_code=1, error="FileNotFoundError: nope", duration_seconds=0
+    )
+    assert errored["status"] == "error"
+    assert errored["error"] == "FileNotFoundError: nope"
+    assert errored["configs"] == []
+
+
+def test_swallowed_contract_errors_surface_as_error_status():
+    failure = {
+        "contract_address": ADDR,
+        "contract_name": "Test",
+        "error": "Failed to communicate with a remote resource: HTTP error: 401",
+    }
+    report = runner.build_json_report(
+        [_result([], [], contract_errors=[failure])],
+        exit_code=0,
+        error=None,
+        duration_seconds=0,
+    )
+
+    # Exit code stays 0 (fail_on_bytecode_comparison_error: false), but the
+    # report must not read as "passed" when nothing was verified.
+    assert report["status"] == "error"
+    assert report["exit_code"] == 0
+    assert report["summary"]["contract_errors"] == 1
+    [contract] = report["configs"][0]["contracts"]
+    assert contract["error"] == failure["error"]
+    assert contract["source"] is None and contract["bytecode"] is None
+
+
+def test_logger_stdout_can_be_muted(capsys, tmp_path):
+    log = Logger(str(tmp_path / "logs.txt"))
+    log.stdout_enabled = False
+    log.info("hidden")
+    log.report_table([[1, "a.sol", True, 0, "a", "r.html"]])
+    log.divider()
+    assert capsys.readouterr().out == ""
+    assert "hidden" in (tmp_path / "logs.txt").read_text()
+
+
+def _run_main(monkeypatch, argv, process_config):
+    monkeypatch.setattr(runner.sys, "argv", ["diffyscan", *argv])
+    monkeypatch.setattr(runner, "load_dotenv", lambda: None)
+    monkeypatch.setattr(runner, "process_config", process_config)
+    monkeypatch.setattr(runner.os.path, "isfile", lambda path: path == "config.yaml")
+    with pytest.raises(SystemExit) as exc_info:
+        runner.main()
+    return exc_info.value.code
+
+
+def test_json_mode_prints_only_json_and_implies_yes(monkeypatch, capsys):
+    seen = {}
+
+    def fake_process_config(path, brownie, binary, cache_e, cache_g, yes, flt):
+        seen["skip_user_input"] = yes
+        return _result([], [_bytecode_stat("failed")], path)
+
+    code = _run_main(monkeypatch, ["config.yaml", "--json"], fake_process_config)
+
+    assert code == 1
+    assert seen["skip_user_input"] is True
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "failed"
+    assert report["summary"]["bytecode"]["failed"] == 1
+
+
+def test_json_mode_reports_exceptions_instead_of_crashing(monkeypatch, capsys):
+    def boom(*args):
+        raise RuntimeError("explorer is down")
+
+    code = _run_main(monkeypatch, ["config.yaml", "-J"], boom)
+
+    assert code == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "error"
+    assert report["error"] == "RuntimeError: explorer is down"
+
+
+def test_human_mode_still_raises(monkeypatch):
+    def boom(*args):
+        raise RuntimeError("explorer is down")
+
+    monkeypatch.setattr(runner.sys, "argv", ["diffyscan", "config.yaml"])
+    monkeypatch.setattr(runner, "load_dotenv", lambda: None)
+    monkeypatch.setattr(runner, "process_config", boom)
+    monkeypatch.setattr(runner.os.path, "isfile", lambda path: path == "config.yaml")
+    with pytest.raises(RuntimeError):
+        runner.main()

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 import diffyscan.diffyscan as runner
-from diffyscan.utils.logger import Logger
+from diffyscan.utils.logger import Logger, bgGreen, bgRed
 
 ADDR = "0x0000000000000000000000000000000000000001"
 
@@ -76,6 +76,7 @@ def _result(source_stats, bytecode_stats, path="config.yaml", contract_errors=No
         "config_path": path,
         "matched_count": 1,
         "interrupted": False,
+        "error": None,
     }
 
 
@@ -183,6 +184,13 @@ def test_logger_stdout_can_be_muted(capsys, tmp_path):
     assert "hidden" in (tmp_path / "logs.txt").read_text()
 
 
+def test_logger_raw_logs_uncolored_line(capsys, tmp_path):
+    log = Logger(str(tmp_path / "logs.txt"))
+    log.raw(f"0001 60 PUSH1 {bgRed('0x01')} {bgGreen('0x02')}")
+    assert (tmp_path / "logs.txt").read_text() == "0001 60 PUSH1 0x01 0x02\n"
+    assert bgRed("0x01") in capsys.readouterr().out
+
+
 def _run_main(monkeypatch, argv, process_config):
     monkeypatch.setattr(runner.sys, "argv", ["diffyscan", *argv])
     monkeypatch.setattr(runner, "load_dotenv", lambda: None)
@@ -219,6 +227,21 @@ def test_json_mode_reports_exceptions_instead_of_crashing(monkeypatch, capsys):
     report = json.loads(capsys.readouterr().out)
     assert report["status"] == "error"
     assert report["error"] == "RuntimeError: explorer is down"
+
+
+def test_json_mode_keeps_results_completed_before_fatal_error(monkeypatch, capsys):
+    def partial(path, *args):
+        result = _result([], [_bytecode_stat()], path)
+        result["error"] = RuntimeError("explorer is down")
+        return result
+
+    code = _run_main(monkeypatch, ["config.yaml", "--json"], partial)
+
+    assert code == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "error"
+    assert report["error"] == "RuntimeError: explorer is down"
+    assert report["summary"]["bytecode"]["exact"] == 1
 
 
 def test_json_mode_reports_interrupted_run_as_error(monkeypatch, capsys):
@@ -263,4 +286,18 @@ def test_human_mode_still_raises(monkeypatch):
     monkeypatch.setattr(runner, "process_config", boom)
     monkeypatch.setattr(runner.os.path, "isfile", lambda path: path == "config.yaml")
     with pytest.raises(RuntimeError):
+        runner.main()
+
+
+def test_human_mode_reraises_error_returned_by_process_config(monkeypatch):
+    def partial(path, *args):
+        result = _result([], [_bytecode_stat()], path)
+        result["error"] = RuntimeError("explorer is down")
+        return result
+
+    monkeypatch.setattr(runner.sys, "argv", ["diffyscan", "config.yaml"])
+    monkeypatch.setattr(runner, "load_dotenv", lambda: None)
+    monkeypatch.setattr(runner, "process_config", partial)
+    monkeypatch.setattr(runner.os.path, "isfile", lambda path: path == "config.yaml")
+    with pytest.raises(RuntimeError, match="explorer is down"):
         runner.main()


### PR DESCRIPTION
## Summary

Adds `--json` / `-J`: instead of the human-readable log, stdout carries a single JSON report meant for scripts and coding agents. Logs still go to `digest/<ts>/logs.txt` (path included in the report), prompts are skipped, and the exit code is unchanged.

The format is specified in `docs/json-output.md` (linked from README, `docs/cli.md`, `CLAUDE.md`, the `debug-diff` skill, and `--help`). Highlights:
- top level: `status` (`passed | failed | error`), `exit_code`, `duration_seconds`, `log_file`, `summary` counters, flat `contracts` list with a `config` field per entry
- per contract: `source` / `bytecode` with status, `facets` + `reason` of the matching `allowed_diffs` rule, diff hunks with line ranges (only files that differ or are missing), `uncovered` bytecode ranges, compile/simulation error text, and a ready `suggested_rule`
- keys with `null` or empty values are omitted, so a clean contract is just `{"status": "exact", "files": 26}`

A fatal error (missing config, bad token) still produces a report with `status: "error"`; the traceback goes to stderr.

## Side finding

With `fail_on_bytecode_comparison_error: false`, a contract that errors out (e.g. explorer 401) was silently dropped from all stats and the run exited 0. Such errors are now recorded in the result and surface in the JSON as `contracts[].error` / `summary.contract_errors`, turning `status` into `error`. The exit code itself is not changed here.

## Other changes

- `Logger.stdout_enabled` switch; two raw `print` calls in `binary_verifier.py` routed through it so JSON mode stays clean
- config discovery extracted into `_collect_config_paths`

## Verification

- 395 tests pass, black, mypy, pre-commit green
- real runs: `lido-earn/mainnet/earn-factory.yaml` gives clean JSON and empty stderr vs 422 log lines; `hypernative-guard/mainnet/config.yaml` reports 4 contracts allowed via `immutables` in 86 lines
- independent review of the first commit with `codex exec review --uncommitted`: no actionable bugs found