### PR TITLE
chore: bump version to 1.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "diffyscan"
-version = "1.0.0"
+version = "1.0.3"
 description = "Diff your Ethereum smart contracts code from GitHub against Blockchain explorer verified source code."
 authors = [{ name = "Azat Serikov", email = "azatsdev@gmail.com" }]
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -207,7 +207,7 @@ wheels = [
 
 [[package]]
 name = "diffyscan"
-version = "1.0.0"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Version in pyproject.toml stayed at 1.0.0 through v1.0.1 and v1.0.2, so `diffyscan --version` and the User-Agent reported 1.0.0. Bump to 1.0.3 ahead of the release.